### PR TITLE
pin pytorch

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -26,7 +26,12 @@ axolotl_image = (
 
 vllm_image = (
     Image.from_registry("nvidia/cuda:12.1.0-base-ubuntu22.04", add_python="3.10")
-    .pip_install("vllm==0.2.5")
+    .pip_install(
+        "vllm==0.2.5",
+        "torch==2.1.2",
+        "torchvision==0.16.2",
+        "torchaudio==2.1.2"
+        )
 )
 
 stub = Stub(APP_NAME, secrets=[Secret.from_name("huggingface")])


### PR DESCRIPTION
New pytorch version created an error when trying to load a model on inference. pinning to the previous pytorch version fixes this.

Before:
![image](https://github.com/modal-labs/llm-finetuning/assets/1820651/ea63c4f8-2a98-4e25-a4f3-499f6ce5202f)

After:
<img width="1572" alt="image" src="https://github.com/modal-labs/llm-finetuning/assets/1820651/70f4af73-380a-4193-992c-eed23031e495">
