### PR TITLE
Update axolotl image and other dependencies

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Run training job on Modal
         run: |
-          GPU_MEM=40 modal run src.train --config=config/${{ matrix.config }}.yml --data=data/sqlqa.jsonl
+          modal run src.train --config=config/${{ matrix.config }}.yml --data=data/sqlqa.jsonl

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Modal
         run: |
           python -m pip install --upgrade pip
-          pip install modal pyyaml
+          pip install modal pyyaml pandas
 
       - name: Prep config and data for CI
         run: |
@@ -39,3 +39,7 @@ jobs:
       - name: Run training job on Modal
         run: |
           modal run src.train --config=config/${{ matrix.config }}.yml --data=data/sqlqa.jsonl
+
+      - name: Check training results
+        run: |
+          python ci/check_loss.py

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,6 @@ on: pull_request
 
 jobs:
   test:
-    environment: CI
     name: Test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Run training job on Modal
         run: |
-          modal run src.train --config=config/${{ matrix.config }}.yml --data=data/sqlqa.jsonl
+          GPU_MEM=40 modal run src.train --config=config/${{ matrix.config }}.yml --data=data/sqlqa.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+
+# Local file written by the training script
+.last_run_folder

--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,4 @@ cython_debug/
 
 
 # Local file written by the training script
-.last_run_folder
+.last_run_name

--- a/ci/check_loss.py
+++ b/ci/check_loss.py
@@ -24,9 +24,8 @@ if __name__ == "__main__":
         results_text = m.group(1).strip().replace(" ", "")
 
     results = pd.read_table(StringIO(results_text), sep="|")
-    print(results)  # TODO debugging
     train_loss = float(results["TrainingLoss"].iloc[-1])
     val_loss = float(results["ValidationLoss"].iloc[-1])
 
-    print("Loss: {train_loss:.2f} (training), {val_loss:.2f} (validation)")
-    sys.exit(val_loss < 0.25)  # Arbitrary threshold
+    print(f"Loss: {train_loss:.2f} (training), {val_loss:.2f} (validation)")
+    sys.exit(val_loss > 0.25)  # Arbitrary threshold

--- a/ci/check_loss.py
+++ b/ci/check_loss.py
@@ -21,11 +21,12 @@ if __name__ == "__main__":
     if m is None:
         sys.exit("Could not parse training results from model card")
     else:
-        results_text = m.group().replace(" ", "")
+        results_text = m.group(1).strip().replace(" ", "")
 
     results = pd.read_table(StringIO(results_text), sep="|")
-    train_loss = results["TrainingLoss"].iloc[-1].astype(float)
-    val_loss = results["ValidationLoss"].iloc[-1].astype(float)
+    print(results)  # TODO debugging
+    train_loss = float(results["TrainingLoss"].iloc[-1])
+    val_loss = float(results["ValidationLoss"].iloc[-1])
 
     print("Loss: {train_loss:.2f} (training), {val_loss:.2f} (validation)")
     sys.exit(val_loss < 0.25)  # Arbitrary threshold

--- a/ci/check_loss.py
+++ b/ci/check_loss.py
@@ -9,12 +9,12 @@ from modal import Volume
 
 if __name__ == "__main__":
 
-    with open(".last_run_folder", "r") as f:
-        run_folder = f.read().strip()
+    with open(".last_run_name", "r") as f:
+        run_name = f.read().strip()
 
     vol = Volume.lookup("example-runs-vol")
     contents = b""
-    for chunk in vol.read_file(f"{run_folder}/lora-out/README.md"):
+    for chunk in vol.read_file(f"{run_name}/lora-out/README.md"):
         contents += chunk
 
     m = re.search(r"### Training results\n\n(.+?)#", contents.decode(), flags=re.DOTALL)

--- a/ci/check_loss.py
+++ b/ci/check_loss.py
@@ -1,0 +1,31 @@
+from io import StringIO
+import re
+import sys
+
+import pandas as pd
+
+from modal import Volume
+
+
+if __name__ == "__main__":
+
+    with open(".last_run_folder", "r") as f:
+        run_folder = f.read().strip()
+
+    vol = Volume.lookup("example-runs-vol")
+    contents = b""
+    for chunk in vol.read_file(f"{run_folder}/lora-out/README.md"):
+        contents += chunk
+
+    m = re.search(r"### Training results\n\n(.+?)#", contents.decode(), flags=re.DOTALL)
+    if m is None:
+        sys.exit("Could not parse training results from model card")
+    else:
+        results_text = m.group().replace(" ", "")
+
+    results = pd.read_table(StringIO(results_text), sep="|")
+    train_loss = results["TrainingLoss"].iloc[-1].astype(float)
+    val_loss = results["ValidationLoss"].iloc[-1].astype(float)
+
+    print("Loss: {train_loss:.2f} (training), {val_loss:.2f} (validation)")
+    sys.exit(val_loss < 0.25)  # Arbitrary threshold

--- a/ci/prep_for_ci.py
+++ b/ci/prep_for_ci.py
@@ -6,20 +6,15 @@ import yaml
 @click.option("--config")
 @click.option("--data")
 def main(config: str, data: str):
-    """Set the config for lighter-weight training and truncate the dataset."""
+    """Set the config to train for only one epoch and truncate the dataset."""
     with open(config) as f:
         cfg = yaml.safe_load(f.read())
-    cfg["sequence_len"] = 1024
-    cfg["val_set_size"] = 100
-    cfg["eval_batch_size"] = 2
-    cfg["micro_batch_size"] = 2
-    cfg["num_epochs"] = 2
-    cfg.pop("eval_steps", None)
+    cfg["num_epochs"] = 1
     with open(config, "w") as f:
         yaml.dump(cfg, f)
 
     with open(data) as f:
-        data_truncated = f.readlines()[:1000]
+        data_truncated = f.readlines()[:2000]
     with open(data, "w") as f:
         f.writelines(data_truncated)
 

--- a/ci/prep_for_ci.py
+++ b/ci/prep_for_ci.py
@@ -13,10 +13,10 @@ def main(config: str, data: str):
     with open(config, "w") as f:
         yaml.dump(cfg, f)
 
-    with open(data) as f:
-        data_truncated = f.readlines()[:2000]
-    with open(data, "w") as f:
-        f.writelines(data_truncated)
+    # with open(data) as f:
+    #     data_truncated = f.readlines()[:2000]
+    # with open(data, "w") as f:
+    #     f.writelines(data_truncated)
 
 
 if __name__ == "__main__":

--- a/ci/prep_for_ci.py
+++ b/ci/prep_for_ci.py
@@ -7,19 +7,18 @@ import yaml
 @click.option("--data")
 def main(config: str, data: str):
     """Set the config to train for only one epoch and truncate the dataset."""
+    train_set_size = 1000
+    val_set_size = 1000
     with open(config) as f:
         cfg = yaml.safe_load(f.read())
-    cfg["sample_packing"] = False
-    cfg["pad_to_sequence_len"] = False
-    cfg["micro_batch_size"] = 32
-    cfg["gradient_accumulation_steps"] = 1
-    cfg["learing_rate"] = 0.0001
+    cfg["val_set_size"] = val_set_size
     cfg["num_epochs"] = 1
+    cfg.pop("eval_steps", None)  # Evaluate once at the end of the epoch
     with open(config, "w") as f:
         yaml.dump(cfg, f)
 
     with open(data) as f:
-        data_truncated = f.readlines()[:1000]
+        data_truncated = f.readlines()[: train_set_size + val_set_size]
     with open(data, "w") as f:
         f.writelines(data_truncated)
 

--- a/ci/prep_for_ci.py
+++ b/ci/prep_for_ci.py
@@ -10,6 +10,7 @@ def main(config: str, data: str):
     with open(config) as f:
         cfg = yaml.safe_load(f.read())
     cfg["sample_packing"] = False
+    cfg["pad_to_sequence_len"] = False
     cfg["micro_batch_size"] = 32
     cfg["gradient_accumulation_steps"] = 1
     cfg["learing_rate"] = 0.0001

--- a/ci/prep_for_ci.py
+++ b/ci/prep_for_ci.py
@@ -9,6 +9,10 @@ def main(config: str, data: str):
     """Set the config to train for only one epoch and truncate the dataset."""
     with open(config) as f:
         cfg = yaml.safe_load(f.read())
+    cfg["sample_packing"] = False
+    cfg["micro_batch_size"] = 32
+    cfg["gradient_accumulation_steps"] = 1
+    cfg["learing_rate"] = 0.0001
     cfg["num_epochs"] = 1
     with open(config, "w") as f:
         yaml.dump(cfg, f)

--- a/ci/prep_for_ci.py
+++ b/ci/prep_for_ci.py
@@ -18,10 +18,10 @@ def main(config: str, data: str):
     with open(config, "w") as f:
         yaml.dump(cfg, f)
 
-    # with open(data) as f:
-    #     data_truncated = f.readlines()[:2000]
-    # with open(data, "w") as f:
-    #     f.writelines(data_truncated)
+    with open(data) as f:
+        data_truncated = f.readlines()[:1000]
+    with open(data, "w") as f:
+        f.writelines(data_truncated)
 
 
 if __name__ == "__main__":

--- a/ci/prep_for_ci.py
+++ b/ci/prep_for_ci.py
@@ -8,7 +8,7 @@ import yaml
 def main(config: str, data: str):
     """Set the config to train for only one epoch and truncate the dataset."""
     train_set_size = 1000
-    val_set_size = 1000
+    val_set_size = 64
     with open(config) as f:
         cfg = yaml.safe_load(f.read())
     cfg["val_set_size"] = val_set_size

--- a/config/codellama.yml
+++ b/config/codellama.yml
@@ -28,9 +28,9 @@ val_set_size: 0.05
 output_dir: ./lora-out
 
 sequence_len: 4096
-sample_packing: true
+sample_packing: false
 eval_sample_packing: false
-pad_to_sequence_len: true
+pad_to_sequence_len: false
 
 adapter: lora
 lora_model_dir:
@@ -46,11 +46,11 @@ wandb_watch:
 wandb_run_id:
 
 gradient_accumulation_steps: 1
-micro_batch_size: 16
-num_epochs: 5
+micro_batch_size: 32
+num_epochs: 4
 optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
-learning_rate: 0.0002
+learning_rate: 0.0001
 
 train_on_inputs: false
 group_by_length: false

--- a/config/codellama.yml
+++ b/config/codellama.yml
@@ -70,7 +70,7 @@ flash_attention: true
 warmup_steps: 10
 eval_steps: 0.05
 save_steps:
-debug: True
+debug:
 deepspeed: /root/axolotl/deepspeed_configs/zero3_bf16.json
 weight_decay: 0.0
 fsdp:

--- a/config/codellama.yml
+++ b/config/codellama.yml
@@ -54,7 +54,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 
@@ -71,7 +71,7 @@ warmup_steps: 10
 eval_steps: 0.05
 save_steps:
 debug: True
-deepspeed: /root/axolotl/deepspeed/zero3.json
+deepspeed: /root/axolotl/deepspeed_configs/zero3_bf16.json
 weight_decay: 0.0
 fsdp:
 fsdp_config:

--- a/config/codellama.yml
+++ b/config/codellama.yml
@@ -48,7 +48,7 @@ wandb_run_id:
 gradient_accumulation_steps: 1
 micro_batch_size: 32
 num_epochs: 4
-optimizer: adamw_bnb_8bit
+optimizer: adamw_torch
 lr_scheduler: cosine
 learning_rate: 0.0001
 

--- a/config/codellama.yml
+++ b/config/codellama.yml
@@ -9,7 +9,7 @@ strict: false
 
 datasets:
   # This will be the path used for the data when it is saved to the Volume in the cloud.
-  - path: my_data.jsonl
+  - path: data.jsonl
     ds_type: json
     type:
       # JSONL file contains question, context, answer fields per line.

--- a/config/llama-2.yml
+++ b/config/llama-2.yml
@@ -3,7 +3,7 @@ model_type: LlamaForCausalLM
 tokenizer_type: LlamaTokenizer
 is_llama_derived_model: true
 
-load_in_8bit: true
+load_in_8bit: false
 load_in_4bit: false
 strict: false
 
@@ -34,8 +34,8 @@ pad_to_sequence_len: false
 
 adapter: lora
 lora_model_dir:
-lora_r: 32
-lora_alpha: 16
+lora_r: 16
+lora_alpha: 32
 lora_dropout: 0.05
 lora_target_linear: true
 lora_fan_in_fan_out:
@@ -44,7 +44,6 @@ wandb_project:
 wandb_entity:
 wandb_watch:
 wandb_run_id:
-wandb_log_model:
 
 gradient_accumulation_steps: 1
 micro_batch_size: 32

--- a/config/llama-2.yml
+++ b/config/llama-2.yml
@@ -28,9 +28,9 @@ val_set_size: 0.05
 output_dir: ./lora-out
 
 sequence_len: 4096
-sample_packing: true
+sample_packing: false
 eval_sample_packing: false
-pad_to_sequence_len: true
+pad_to_sequence_len: false
 
 adapter: lora
 lora_model_dir:
@@ -46,12 +46,12 @@ wandb_watch:
 wandb_run_id:
 wandb_log_model:
 
-gradient_accumulation_steps: 4
-micro_batch_size: 2
+gradient_accumulation_steps: 1
+micro_batch_size: 32
 num_epochs: 4
 optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
-learning_rate: 0.0002
+learning_rate: 0.0001
 
 train_on_inputs: false
 group_by_length: false

--- a/config/llama-2.yml
+++ b/config/llama-2.yml
@@ -48,7 +48,7 @@ wandb_run_id:
 gradient_accumulation_steps: 1
 micro_batch_size: 32
 num_epochs: 4
-optimizer: adamw_bnb_8bit
+optimizer: adamw_torch
 lr_scheduler: cosine
 learning_rate: 0.0001
 

--- a/config/llama-2.yml
+++ b/config/llama-2.yml
@@ -9,7 +9,7 @@ strict: false
 
 datasets:
   # This will be the path used for the data when it is saved to the Volume in the cloud.
-  - path: my_data.jsonl
+  - path: data.jsonl
     ds_type: json
     type:
       # JSONL file contains question, context, answer fields per line.

--- a/config/mistral.yml
+++ b/config/mistral.yml
@@ -27,7 +27,7 @@ dataset_prepared_path:
 val_set_size: 32
 output_dir: ./lora-out
 
-sequence_len: 2048
+sequence_len: 4096
 sample_packing: false
 eval_sample_packing: false
 pad_to_sequence_len: false

--- a/config/mistral.yml
+++ b/config/mistral.yml
@@ -28,9 +28,9 @@ val_set_size: 32
 output_dir: ./lora-out
 
 sequence_len: 2048
-sample_packing: true
+sample_packing: false
 eval_sample_packing: false
-pad_to_sequence_len: true
+pad_to_sequence_len: false
 
 adapter: lora
 lora_model_dir:
@@ -46,11 +46,11 @@ wandb_watch:
 wandb_run_id:
 
 gradient_accumulation_steps: 1
-micro_batch_size: 16
-num_epochs: 1
+micro_batch_size: 32
+num_epochs: 4
 optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
-learning_rate: 0.0002
+learning_rate: 0.0001
 
 bf16: auto
 fp16: false

--- a/config/mistral.yml
+++ b/config/mistral.yml
@@ -24,7 +24,7 @@ datasets:
         {instruction} [/INST] 
 
 dataset_prepared_path:
-val_set_size: 32
+val_set_size: 0.05
 output_dir: ./lora-out
 
 sequence_len: 4096

--- a/config/mistral.yml
+++ b/config/mistral.yml
@@ -52,7 +52,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 train_on_inputs: false
@@ -69,7 +69,7 @@ flash_attention: false
 warmup_steps: 10
 save_steps:
 debug:
-deepspeed: /root/axolotl/deepspeed/zero3.json
+deepspeed: /root/axolotl/deepspeed_configs/zero3_bf16.json
 weight_decay: 0.0
 fsdp:
 fsdp_config:

--- a/config/mistral.yml
+++ b/config/mistral.yml
@@ -48,7 +48,7 @@ wandb_run_id:
 gradient_accumulation_steps: 1
 micro_batch_size: 32
 num_epochs: 4
-optimizer: adamw_bnb_8bit
+optimizer: adamw_torch
 lr_scheduler: cosine
 learning_rate: 0.0001
 

--- a/config/mistral.yml
+++ b/config/mistral.yml
@@ -64,7 +64,7 @@ resume_from_checkpoint:
 local_rank:
 logging_steps: 1
 xformers_attention:
-flash_attention: false
+flash_attention: true
 
 warmup_steps: 10
 save_steps:

--- a/config/mistral.yml
+++ b/config/mistral.yml
@@ -9,7 +9,7 @@ strict: false
 
 datasets:
   # This will be the path used for the data when it is saved to the Volume in the cloud.
-  - path: my_data.jsonl
+  - path: data.jsonl
     ds_type: json
     type:
       # JSONL file contains question, context, answer fields per line.

--- a/src/common.py
+++ b/src/common.py
@@ -1,6 +1,6 @@
 from pathlib import PurePosixPath
 
-from modal import Stub, Image, Volume, Secret
+from modal import Stub, Image, Volume
 
 APP_NAME = "example-axolotl"
 
@@ -26,7 +26,7 @@ vllm_image = Image.from_registry(
     "torch==2.1.2",
 )
 
-stub = Stub(APP_NAME)  # , secrets=[Secret.from_name("huggingface")])
+stub = Stub(APP_NAME)
 
 # Volumes for pre-trained models and training runs.
 pretrained_volume = Volume.persisted("example-pretrained-vol")

--- a/src/common.py
+++ b/src/common.py
@@ -3,24 +3,18 @@ import os
 
 APP_NAME = "example-axolotl"
 
-# Latest image hash of winglian/axolotl:main-py3.10-cu118-2.0.1 (2023-12-11)
+# Axolotl image hash corresponding to 0.4.0 release
 AXOLOTL_REGISTRY_SHA = (
-    "5c19a5154fd522225953b9c3f6206750f4191e0e92ee424f02963f7963ada698"
+    "af4d878e9fbc90c7ba30fa78ce4d6d95b1ccba398ab944efbd322d7c0d6313c8"
 )
-# Need to patch transformers to an older version to avoid checkpointing errors.
-TRANSFORMERS_SHA = "5324bf9c07c318015eccc5fba370a81368a8df28"
 
 axolotl_image = (
     Image.from_registry(f"winglian/axolotl@sha256:{AXOLOTL_REGISTRY_SHA}")
     .run_commands(
         "git clone https://github.com/OpenAccess-AI-Collective/axolotl /root/axolotl",
-        "cd /root/axolotl && git checkout a581e9f8f66e14c22ec914ee792dd4fe073e62f6",
+        "cd /root/axolotl && git checkout v0.4.0",
     )
     .pip_install("huggingface_hub==0.19.4", "hf-transfer==0.1.4")
-    .pip_install(
-        f"transformers @ git+https://github.com/huggingface/transformers.git@{TRANSFORMERS_SHA}",
-        "--force-reinstall",
-    )
     .env(dict(HUGGINGFACE_HUB_CACHE="/pretrained", HF_HUB_ENABLE_HF_TRANSFER="1"))
 )
 
@@ -29,8 +23,6 @@ vllm_image = Image.from_registry(
 ).pip_install(
     "vllm==0.2.5",
     "torch==2.1.2",
-    "torchvision==0.16.2",
-    "torchaudio==2.1.2",
 )
 
 stub = Stub(APP_NAME)  # , secrets=[Secret.from_name("huggingface")])

--- a/src/common.py
+++ b/src/common.py
@@ -1,5 +1,6 @@
+from pathlib import PurePosixPath
+
 from modal import Stub, Image, Volume, Secret
-import os
 
 APP_NAME = "example-axolotl"
 
@@ -30,7 +31,7 @@ stub = Stub(APP_NAME)  # , secrets=[Secret.from_name("huggingface")])
 # Volumes for pre-trained models and training runs.
 pretrained_volume = Volume.persisted("example-pretrained-vol")
 runs_volume = Volume.persisted("example-runs-vol")
-VOLUME_CONFIG: dict[str | os.PathLike, Volume] = {
+VOLUME_CONFIG: dict[str | PurePosixPath, Volume] = {
     "/pretrained": pretrained_volume,
     "/runs": runs_volume,
 }

--- a/src/common.py
+++ b/src/common.py
@@ -15,7 +15,7 @@ axolotl_image = (
         "git clone https://github.com/OpenAccess-AI-Collective/axolotl /root/axolotl",
         "cd /root/axolotl && git checkout v0.4.0",
     )
-    .pip_install("huggingface_hub==0.19.4", "hf-transfer==0.1.4")
+    .pip_install("huggingface_hub==0.20.3", "hf-transfer==0.1.5")
     .env(dict(HUGGINGFACE_HUB_CACHE="/pretrained", HF_HUB_ENABLE_HF_TRANSFER="1"))
 )
 

--- a/src/train.py
+++ b/src/train.py
@@ -10,7 +10,7 @@ from .common import (
 )
 
 N_GPUS = int(os.environ.get("N_GPUS", 2))
-GPU_MEM = int(os.environ.get("GPU_MEM", 80))
+GPU_MEM = int(os.environ.get("GPU_MEM", 40))
 GPU_CONFIG = modal.gpu.A100(count=N_GPUS, memory=GPU_MEM)
 
 

--- a/src/train.py
+++ b/src/train.py
@@ -139,7 +139,11 @@ def main(
 ):
     # Read config.yml and my_data.jsonl and pass them to the new function.
     with open(config, "r") as cfg, open(data, "r") as dat:
-        _, train_handle = launch.remote(cfg.read(), dat.read())
+        run_folder, train_handle = launch.remote(cfg.read(), dat.read())
+
+    # Write a local refernce to the location on the remote volume with the run
+    with open(".last_run_folder", "w") as f:
+        f.write(run_folder)
 
     # Wait for the training run to finish.
     merge_handle = train_handle.get()

--- a/src/train.py
+++ b/src/train.py
@@ -79,13 +79,7 @@ def merge(run_folder: str):
     shutil.rmtree(f"{run_folder}/lora-out/merged", ignore_errors=True)
 
     with open(f"{run_folder}/config.yml") as config:
-        # Loading ./lora-out saved by deepspeed has issues, use latest checkpoint instead.
-        if yaml.safe_load(config).get("deepspeed", None):
-            checkpoints = glob.glob(f"./lora-out/checkpoint-*", root_dir=run_folder)
-            MERGE_SRC = max(checkpoints, key=lambda path: int(path.split("-")[-1]))
-        else:
-            MERGE_SRC = "./lora-out"
-
+        MERGE_SRC = "./lora-out"
         print(f"Merge from {MERGE_SRC} in {run_folder}")
 
     MERGE_CMD = f"accelerate launch -m axolotl.cli.merge_lora ./config.yml --lora_model_dir='{MERGE_SRC}'"

--- a/src/train.py
+++ b/src/train.py
@@ -110,7 +110,8 @@ def launch(config_raw: str, data_raw: str):
 
     # Write config and data into a training subfolder.
     time_string = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-    run_folder = f"/runs/axo-{time_string}-{secrets.token_hex(2)}"
+    run_name = f"axo-{time_string}-{secrets.token_hex(2)}"
+    run_folder = f"/runs/{run_name}"
     os.makedirs(run_folder)
 
     print(f"Preparing training run in {run_folder}.")
@@ -129,7 +130,7 @@ def launch(config_raw: str, data_raw: str):
         f.write(f"train: https://modal.com/logs/call/{train_handle.object_id}")
     VOLUME_CONFIG["/runs"].commit()
 
-    return run_folder, train_handle
+    return run_name, train_handle
 
 
 @stub.local_entrypoint()
@@ -139,11 +140,11 @@ def main(
 ):
     # Read config.yml and my_data.jsonl and pass them to the new function.
     with open(config, "r") as cfg, open(data, "r") as dat:
-        run_folder, train_handle = launch.remote(cfg.read(), dat.read())
+        run_name, train_handle = launch.remote(cfg.read(), dat.read())
 
     # Write a local refernce to the location on the remote volume with the run
-    with open(".last_run_folder", "w") as f:
-        f.write(run_folder)
+    with open(".last_run_name", "w") as f:
+        f.write(run_name)
 
     # Wait for the training run to finish.
     merge_handle = train_handle.get()

--- a/src/train.py
+++ b/src/train.py
@@ -138,7 +138,7 @@ def main(
     config: str,
     data: str,
 ):
-    # Read config.yml and my_data.jsonl and pass them to the new function.
+    # Read config and data source files and pass their contents to the remote function.
     with open(config, "r") as cfg, open(data, "r") as dat:
         run_name, train_handle = launch.remote(cfg.read(), dat.read())
 

--- a/src/train.py
+++ b/src/train.py
@@ -88,7 +88,7 @@ def merge(run_folder: str):
 
         print(f"Merge from {MERGE_SRC} in {run_folder}")
 
-    MERGE_CMD = f"accelerate launch -m axolotl.cli.merge_lora ./config.yml --lora_model_dir='{MERGE_SRC}' --load_in_8bit=False --load_in_4bit=False --flash_attention=False"
+    MERGE_CMD = f"accelerate launch -m axolotl.cli.merge_lora ./config.yml --lora_model_dir='{MERGE_SRC}'"
     run_cmd(MERGE_CMD, run_folder)
 
     VOLUME_CONFIG["/runs"].commit()


### PR DESCRIPTION
The primary change here is to update the version of the `axolotl` container to correspond to the v0.4.0 release. There are also some changes directly downstream of that:

- We no longer install an older checkout of `transformers`
- Mistral no longer hangs on evaluation with `flash_attention` enabled
- We've updated the `deepspeed` config paths

Additionally, I've made some updates to the configs that aren't strictly related to the axolotl version, but arose from the testing that I was doing:

- I've disabled `sample_packing` which seems to be on net harmful for the medium-sized finetuning dataset we use in our demonstration.
- (Mostly as a result of the above) I downgraded the base GPU request to use 2 40-GB A100s, which are easier to get
- I aligned the configs between the three models (mainly this means removing quantization from Llama-2). I suspect that it's confusing to use different configs for different base models; new users could interpret that as "you train mistral at half native precision but have to use quantization for llama", or something similar.

Finally, I updated some of the CI that I added in a previous PR:

- I removed some of the configuration changes that made the CI training "lighter weight", now all I change is running on a truncated dataset for a single epoch, with just one evaluation at the end of the epoch
- I added on assertion on the validation loss. This involves some pretty hacky stuff as I don't see any obvious way to get structured results from the axolotl outputs (without going through mlflow or wandb, which maybe would have been better)

Despite being fairly lightweight and taking just a couple of minutes, the models that train in CI seem pretty good! (evaluation loss of ≈0.06 for Mistral).