### PR TITLE
Use output_dir as specified in config

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-      MODAL_ENVIRONMENT: CI-CD
+      MODAL_ENVIRONMENT: ci-llm-finetuning
 
     steps:
       - name: Checkout Repository

--- a/config/mistral.yml
+++ b/config/mistral.yml
@@ -47,7 +47,7 @@ wandb_run_id:
 
 gradient_accumulation_steps: 1
 micro_batch_size: 32
-num_epochs: 4
+num_epochs: 1
 optimizer: adamw_torch
 lr_scheduler: cosine
 learning_rate: 0.0001

--- a/config/mistral.yml
+++ b/config/mistral.yml
@@ -47,7 +47,7 @@ wandb_run_id:
 
 gradient_accumulation_steps: 1
 micro_batch_size: 32
-num_epochs: 1
+num_epochs: 4
 optimizer: adamw_torch
 lr_scheduler: cosine
 learning_rate: 0.0001

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,5 +1,4 @@
 # Optional stand-alone helper GUI to call the backend training functions.
-from pathlib import Path
 
 import modal
 
@@ -35,7 +34,7 @@ def gui(config_raw: str, data_raw: str):
         VOLUME_CONFIG["/runs"].reload()
 
         md = "|Run|Checkpoint (steps)|Merged|Logs|\n|-|-|-|-|\n"
-        for run in reversed(sorted(Path("/runs").glob("*"))):
+        for run in reversed(sorted(glob.glob("/runs/*"))):
             checkpoints = [
                 int(path.split("-")[-1])
                 for path in glob.glob(f"{run}/{output_dir}/checkpoint-*")


### PR DESCRIPTION
Users can override `output_dir` in their config file(s) but some places in the code assumed we were writing outputs to `./lora-out` as we do in the example configs. This always makes downstream steps look for run output in the config-specified `output_dir`.

Resolves MOD-2487