### PR TITLE
Add web endpoint to the inference server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ modal run --detach src.train --config=config/mistral.yml --data=data/sqlqa.jsonl
 4. Try the model from a completed training run. You can select a folder via `modal volume ls example-runs-vol`, and then specify the training folder with the `--run-folder` flag (something like `/runs/axo-2023-11-24-17-26-66e8`) for inference:
 
 ```bash
-modal run -q src.inference --run-folder /runs/<run_tag>
+modal run -q src.inference --run-name <run_tag>
 ```
 
 Our quickstart example trains a 7B model on a text-to-SQL dataset as a proof of concept (it takes just a few minutes). It uses DeepSpeed ZeRO-3 to shard the model state across 2 A100s. Inference on the fine-tuned model displays conformity to the output structure (`[SQL] ... [/SQL]`). To achieve better results, you would need to use more data! Refer to the full development section below.

--- a/ci/check_inference.py
+++ b/ci/check_inference.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
 CREATE TABLE head (age INTEGER)
 How many heads of the departments are older than 56 ? [/INST] """
 
-    p = subprocess.Popen(["modal", "run", "src.inference", "--run-folder", f"/runs/{run_name}", "--prompt", prompt], stdout=subprocess.PIPE)
+    p = subprocess.Popen(["modal", "run", "src.inference", "--run-name", run_name, "--prompt", prompt], stdout=subprocess.PIPE)
     output = ""
 
     for line in iter(p.stdout.readline, b''):

--- a/src/inference.py
+++ b/src/inference.py
@@ -18,9 +18,9 @@ N_INFERENCE_GPU = 2
     container_idle_timeout=120,
 )
 class Inference:
-    def __init__(self, run_name: str = "", model_dir: str = "/runs") -> None:
+    def __init__(self, run_name: str = "", run_dir: str = "/runs") -> None:
         self.run_name = run_name
-        self.model_dir = model_dir
+        self.run_dir = run_dir
 
     @modal.enter()
     def init(self):
@@ -28,13 +28,13 @@ class Inference:
             run_name = self.run_name
         else:
             # Pick the last run automatically
-            run_name = VOLUME_CONFIG[self.model_dir].listdir("/")[-1].path
+            run_name = VOLUME_CONFIG[self.run_dir].listdir("/")[-1].path
 
         # Grab the output dir (usually "lora-out")
-        with open(f"{self.model_dir}/{run_name}/config.yml") as f:
+        with open(f"{self.run_dir}/{run_name}/config.yml") as f:
             output_dir = yaml.safe_load(f.read())["output_dir"]
 
-        model_path = f"{self.model_dir}/{run_name}/{output_dir}/merged"
+        model_path = f"{self.run_dir}/{run_name}/{output_dir}/merged"
         print("Initializing vLLM engine on:", model_path)
 
         from vllm.engine.arg_utils import AsyncEngineArgs

--- a/src/inference.py
+++ b/src/inference.py
@@ -9,6 +9,12 @@ from .common import stub, vllm_image, VOLUME_CONFIG
 
 N_INFERENCE_GPU = 2
 
+with vllm_image.imports():
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.engine.async_llm_engine import AsyncLLMEngine
+    from vllm.sampling_params import SamplingParams
+    from vllm.utils import random_uuid
+
 
 @stub.cls(
     gpu=modal.gpu.H100(count=N_INFERENCE_GPU),
@@ -37,9 +43,6 @@ class Inference:
         model_path = f"{self.run_dir}/{run_name}/{output_dir}/merged"
         print("Initializing vLLM engine on:", model_path)
 
-        from vllm.engine.arg_utils import AsyncEngineArgs
-        from vllm.engine.async_llm_engine import AsyncLLMEngine
-
         engine_args = AsyncEngineArgs(
             model=model_path,
             gpu_memory_utilization=0.95,
@@ -50,9 +53,6 @@ class Inference:
     async def _stream(self, input: str):
         if not input:
             return
-
-        from vllm.sampling_params import SamplingParams
-        from vllm.utils import random_uuid
 
         sampling_params = SamplingParams(
             repetition_penalty=1.1,

--- a/src/train.py
+++ b/src/train.py
@@ -150,4 +150,4 @@ def main(
 
     print(f"Training complete. Run tag: {run_name}")
     print(f"To inspect weights, run `modal volume ls example-runs-vol {run_name}`")
-    print(f"To run sample inference, run `modal run -q src.inference --run-folder /runs/{run_name}`")
+    print(f"To run sample inference, run `modal run -q src.inference --run-name {run_name}`")


### PR DESCRIPTION
This lets you do

`modal serve src.inference`

in one window, and

`curl 'https://modal-labs--example-axolotl-inference-web-dev.modal.run?input=what+time+is+it'` in another window

it streams!

Note that most of the complexity here is that we want to support an unparametrized class constructor, so we need to pick the run id automatically. In order to do that it was slightly easier to change the argument to be `run_name` rather than the full path. If `run_name` isn't provided (which it never is in the case of web endpoints, since we don't support parametrized functions with web endpoints), then it just picks the last run by doing a directory listing.