### PR TITLE
Add lightweight Pythia config and a few small tweaks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ["codellama", "llama-2", "mistral", "mixtral"]
+        config: ["codellama", "llama-2", "mistral", "mixtral", "pythia"]
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}

--- a/ci/prep_for_ci.py
+++ b/ci/prep_for_ci.py
@@ -12,7 +12,10 @@ def main(config: str, data: str):
 
     if cfg["sample_packing"]:
         train_set_size = 2048
-        num_epochs = 10
+        num_epochs = 4
+    elif "pythia" in cfg["base_model"]:
+        train_set_size = 3200
+        num_epochs = 1
     else:
         train_set_size = 1024
         num_epochs = 1

--- a/config/mixtral.yml
+++ b/config/mixtral.yml
@@ -73,7 +73,7 @@ micro_batch_size: 8
 num_epochs: 1
 optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
-learning_rate: 0.0002
+learning_rate: 0.001
 
 train_on_inputs: false
 group_by_length: false

--- a/config/pythia.yml
+++ b/config/pythia.yml
@@ -1,0 +1,81 @@
+# Lightweight example of training a small Pythia model for simple demonstrations
+base_model: EleutherAI/pythia-1.4b-deduped
+model_type: AutoModelForCausalLM
+tokenizer_type: AutoTokenizer
+
+load_in_8bit: false
+load_in_4bit: false
+strict: false
+
+datasets:
+  # This will be the path used for the data when it is saved to the Volume in the cloud.
+  - path: data.jsonl
+    ds_type: json
+    type:
+      # JSONL file contains question, context, answer fields per line.
+      # This gets mapped to instruction, input, output axolotl tags.
+      field_instruction: question
+      field_input: context
+      field_output: answer
+      # Format is used by axolotl to generate the prompt.
+      format: |-
+        [INST] Using the schema context below, generate a SQL query that answers the question.
+        {input}
+        {instruction} [/INST] 
+
+dataset_prepared_path:
+val_set_size: 0.05
+output_dir: ./lora-out
+
+sequence_len: 4096
+sample_packing: false
+eval_sample_packing: false
+pad_to_sequence_len: false
+
+adapter: lora
+lora_model_dir:
+lora_r: 16
+lora_alpha: 32
+lora_dropout: 0.05
+lora_target_linear: true
+lora_fan_in_fan_out:
+lora_target_modules:
+  - query_key_value
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_run_id:
+
+gradient_accumulation_steps: 1
+micro_batch_size: 32
+num_epochs: 1
+optimizer: adamw_torch
+lr_scheduler: cosine
+learning_rate: 0.0001
+
+bf16: auto
+fp16: false
+tf32: false
+train_on_inputs: false
+group_by_length: false
+
+gradient_checkpointing: true
+early_stopping_patience:
+resume_from_checkpoint:
+local_rank:
+logging_steps: 1
+xformers_attention:
+flash_attention: 
+
+warmup_steps: 10
+save_steps:
+debug:
+deepspeed: 
+weight_decay: 0.0
+fsdp:
+fsdp_config:
+special_tokens:
+  bos_token: "<|endoftext|>"
+  eos_token: "<|endoftext|>"
+  unk_token: "<|endoftext|>"

--- a/src/common.py
+++ b/src/common.py
@@ -16,7 +16,13 @@ axolotl_image = (
         "cd /root/axolotl && git checkout v0.4.0",
     )
     .pip_install("huggingface_hub==0.20.3", "hf-transfer==0.1.5")
-    .env(dict(HUGGINGFACE_HUB_CACHE="/pretrained", HF_HUB_ENABLE_HF_TRANSFER="1"))
+    .env(
+        dict(
+            HUGGINGFACE_HUB_CACHE="/pretrained",
+            HF_HUB_ENABLE_HF_TRANSFER="1",
+            TQDM_DISABLE="true",
+        )
+    )
 )
 
 vllm_image = Image.from_registry(

--- a/src/inference.py
+++ b/src/inference.py
@@ -1,5 +1,4 @@
 import time
-from pathlib import Path
 import yaml
 
 import modal

--- a/src/train.py
+++ b/src/train.py
@@ -11,7 +11,7 @@ from .common import (
 )
 
 N_GPUS = int(os.environ.get("N_GPUS", 2))
-GPU_CONFIG = modal.gpu.H100(count=N_GPUS)
+GPU_CONFIG = os.environ.get("GPU_CONFIG", modal.gpu.H100(count=N_GPUS))
 
 
 def print_common_training_issues(config):
@@ -150,4 +150,6 @@ def main(
 
     print(f"Training complete. Run tag: {run_name}")
     print(f"To inspect weights, run `modal volume ls example-runs-vol {run_name}`")
-    print(f"To run sample inference, run `modal run -q src.inference --run-name {run_name}`")
+    print(
+        f"To run sample inference, run `modal run -q src.inference --run-name {run_name}`"
+    )


### PR DESCRIPTION
Adds a config that trains `pythia-1.4B` for a single epoch, which may be useful for (relatively) quick demonstrations.

Also a couple independent but helpful updates:

- `tqdm` progress bars are now disabled during training, providing cleaner output
- The training GPU configuration can be overridden with a `GPU_CONFIG` environment variable