### PR TITLE
Pin numpy<2 in vLLM image

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -40,6 +40,7 @@ vllm_image = modal.Image.from_registry(
 ).pip_install(
     "vllm==0.2.6",
     "torch==2.1.2",
+    "numpy<2",  # To avoid vLLM ecosystem compatibility issues
 )
 
 app = modal.App(


### PR DESCRIPTION
With the numpy 2.0 release, inference workflows are running into problems arising from vLLM incompatibility. It seems like it may actually be an issue in a transitive vLLM dependency? (https://github.com/vllm-project/vllm/pull/5582). Overall the story is not so clear, so let's just pin numpy on 1.x for now.