### PR TITLE
fix: deprecation warnings

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -49,7 +49,7 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
-          modal run src.train --config=config/${{ matrix.config }}.yml --data=data/sqlqa.subsample.jsonl
+          modal run -m src.train --config=config/${{ matrix.config }}.yml --data=data/sqlqa.subsample.jsonl
 
       - name: Check training results
         env:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or hundreds of A100 or A10G instances running production inference.
 Our sample configurations use many of the recommended, state-of-the-art optimizations for efficient, performant training that `axolotl` supports, including:
 
 - [**Deepspeed ZeRO**](https://www.deepspeed.ai/) to utilize multiple GPUs during training, according to a strategy you configure.
-- [**LoRA Adapters**]() for fast, parameter-efficient fine-tuning.
+- [**LoRA Adapters**](https://arxiv.org/abs/2106.09685) for fast, parameter-efficient fine-tuning.
 - [**Flash attention**](https://github.com/Dao-AILab/flash-attention) for fast and memory-efficient attention calculations during training.
 
 ## Quickstart
@@ -49,9 +49,10 @@ Inference on the fine-tuned model displays conformity to the output structure (`
    ```
 
 3. **Launch a finetuning job**:
+
    ```bash
    export ALLOW_WANDB=true  # if you're using Weights & Biases
-   modal run --detach src.train --config=config/mistral-memorize.yml --data=data/sqlqa.subsample.jsonl
+   modal run --detach -m src.train --config=config/mistral-memorize.yml --data=data/sqlqa.subsample.jsonl
    ```
 
 This example training script is opinionated in order to make it easy to get started. Feel free to adapt it to suit your needs.
@@ -60,7 +61,7 @@ This example training script is opinionated in order to make it easy to get star
 
 ```bash
 # run one test inference
-modal run -q src.inference --prompt "[INST] Using the schema context below, generate a SQL query that answers the question.
+modal run --quiet -m src.inference --prompt "[INST] Using the schema context below, generate a SQL query that answers the question.
 CREATE TABLE head (name VARCHAR, born_state VARCHAR, age VARCHAR)
 List the name, born state and age of the heads of departments ordered by name. [/INST]"
 # 🤖:  [SQL] SELECT name, born_state, age FROM head ORDER BY name [/SQL]  # or something like that!
@@ -107,13 +108,15 @@ You can view some example configurations in `config` for a quick start with diff
 
 The most important options to consider are:
 
-**Model**
+#### Model
 
 ```yaml
 base_model: mistralai/Mistral-7B-v0.1
 ```
 
-**Dataset** (You can see all dataset options [here](https://github.com/axolotl-ai-cloud/axolotl#dataset))
+#### Dataset
+
+You can see all dataset options [here](https://github.com/axolotl-ai-cloud/axolotl#dataset).
 
 ```yaml
 datasets:
@@ -133,7 +136,7 @@ datasets:
         {instruction} [/INST]
 ```
 
-**LoRA**
+#### LoRA
 
 ```yaml
 adapter: lora # for qlora, or leave blank for full finetune (requires much more GPU memory!)
@@ -143,11 +146,11 @@ lora_dropout: 0.05
 lora_target_linear: true # target all linear layers
 ```
 
-**Custom Datasets**
+#### Custom Datasets
 
 `axolotl` supports [many dataset formats](https://github.com/axolotl-ai-cloud/axolotl#dataset). We recommend adding your custom dataset as a `.jsonl` file in the `data` folder and making the appropriate modifications to your config.
 
-**Logging with Weights and Biases**
+#### Logging with Weights and Biases
 
 To track your training runs with Weights and Biases, add your `wandb` config information to your `config.yml`:
 
@@ -159,7 +162,7 @@ wandb_watch: gradients # track histograms of gradients
 and set the `ALLOW_WANDB` environment variable to `true` when launching your training job:
 
 ```bash
-ALLOW_WANDB=true modal run --detach src.train --config=... --data=...
+ALLOW_WANDB=true modal run --detach -m src.train --config=... --data=...
 ```
 
 ### Multi-GPU training
@@ -176,7 +179,7 @@ and then when you launch your training job,
 set the `GPU_CONFIG` environment variable to the GPU configuration you want to use:
 
 ```bash
-GPU_CONFIG=a100-80gb:4 modal run --detach src.train --config=... --data=...
+GPU_CONFIG=a100-80gb:4 modal run --detach -m src.train --config=... --data=...
 ```
 
 ### Finding and using your weights
@@ -200,7 +203,7 @@ By default, the Modal `axolotl` trainer automatically merges the LoRA adapter we
 
 The directory for a finished run will look like something this:
 
-```
+```bash
 $ modal volume ls example-runs-vol axo-2024-04-13-19-13-05-0fb0/
 
 Directory listing of 'axo-2024-04-13-19-13-05-0fb0/' in 'example-runs-vol'
@@ -216,12 +219,12 @@ Directory listing of 'axo-2024-04-13-19-13-05-0fb0/' in 'example-runs-vol'
 └────────────────────────────────────────────────┴──────┴───────────────────────────┴─────────┘
 ```
 
-The LoRA adapters are stored in `lora-out`. The merged weights are stored in `lora-out/merged `. Note that many inference frameworks can only load the merged weights!
+The LoRA adapters are stored in `lora-out`. The merged weights are stored in `lora-out/merged`. Note that many inference frameworks can only load the merged weights!
 
 To run inference with a model from a past training job, you can specify the run name via the command line:
 
 ```bash
-modal run -q src.inference --run-name=...
+modal run --quiet -m src.inference --run-name=...
 ```
 
 ## Common Errors

--- a/src/train.py
+++ b/src/train.py
@@ -31,7 +31,7 @@ def train(run_folder: str, output_dir: str):
     print(f"Using {torch.cuda.device_count()} {torch.cuda.get_device_name()} GPU(s).")
 
     ALLOW_WANDB = os.environ.get("ALLOW_WANDB", "false").lower() == "true"
-    cmd = f"accelerate launch -m axolotl.cli.train ./config.yml {'--wandb_mode disabled' if not ALLOW_WANDB else ''}"
+    cmd = f"accelerate launch --num_processes {torch.cuda.device_count()} --num_machines 1 --mixed_precision no --dynamo_backend no -m axolotl.cli.train ./config.yml {'--wandb_mode disabled' if not ALLOW_WANDB else ''}"
     run_cmd(cmd, run_folder)
 
     # Kick off CPU job to merge the LoRA weights into base model.
@@ -64,6 +64,7 @@ def preproc_data(run_folder: str):
 )
 def merge(run_folder: str, output_dir: str):
     import shutil
+    import torch
 
     output_path = Path(run_folder) / output_dir
     shutil.rmtree(output_path / "merged", ignore_errors=True)
@@ -71,7 +72,7 @@ def merge(run_folder: str, output_dir: str):
     with open(f"{run_folder}/config.yml"):
         print(f"Merge from {output_path}")
 
-    MERGE_CMD = f"accelerate launch -m axolotl.cli.merge_lora ./config.yml --lora_model_dir='{output_dir}'"
+    MERGE_CMD = f"accelerate launch --num_processes {torch.cuda.device_count()} --num_machines 1 --mixed_precision no --dynamo_backend no -m axolotl.cli.merge_lora ./config.yml --lora_model_dir='{output_dir}'"
     run_cmd(MERGE_CMD, run_folder)
 
     VOLUME_CONFIG["/runs"].commit()
@@ -146,7 +147,7 @@ def main(
     data: str,
     merge_lora: bool = True,
     preproc_only: bool = False,
-    run_to_resume: str = None,
+    run_to_resume: str = "",
 ):
     # Read config and data source files and pass their contents to the remote function.
     with open(config, "r") as cfg, open(data, "r") as dat:
@@ -167,7 +168,7 @@ def main(
     print(f"To inspect outputs, run `modal volume ls example-runs-vol {run_name}`")
     if not preproc_only:
         print(
-            f"To run sample inference, run `modal run -q src.inference --run-name {run_name}`"
+            f"To run sample inference, run `modal run --quiet -m src.inference --run-name {run_name}`"
         )
 
 


### PR DESCRIPTION
These changes fix the following deprecation warnings that appear when running `modal run --detach -m src.train ...` with recent modal-client versions like 0.74.40.

* [Requiring explicit invocation for module mode][1]
* [Renaming autoscaler parameters][2]
* [Replacing `allow_concurrent_inputs` with `@modal.concurrent`][3]
* [Renaming `modal.web_endpoint` to `modal.fastapi_endpoint`][4]
* [Removing support for custom Cls constructors][5]
* The following `accelerate launch` warnings in both `train.py` and `inference.py`.

```
The following values were not passed to `accelerate launch` and had defaults used instead:
  `--num_processes` was set to a value of `2` More than one GPU was found, enabling multi-GPU training. If this was unintended please pass in `--num_processes=1`.
  `--num_machines` was set to a value of `1`
  `--mixed_precision` was set to a value of `'no'`
  `--dynamo_backend` was set to a value of `'no'`
```

[1]: https://modal.com/docs/guide/modal-1-0-migration#requiring-explicit-invocation-for-module-mode
[2]: https://modal.com/docs/guide/modal-1-0-migration#renaming-autoscaler-parameters
[3]: https://modal.com/docs/guide/modal-1-0-migration#replacing-allow_concurrent_inputs-with-modalconcurrent
[4]: https://modal.com/docs/guide/modal-1-0-migration#renaming-modalweb_endpoint-to-modalfastapi_endpoint
[5]: https://modal.com/docs/guide/modal-1-0-migration#removing-support-for-custom-cls-constructors

## Miscellaneous changes

* Make some minor Markdown formatting fixes to fix some linter warnings.
* Use `modal run --quiet` instead of `-q` to make it more obvious what the flag does.

<details>
<summary>before</summary>

```bash
$ modal run --detach -m src.train --config=config/mistral.yml --data=data/sqlqa.jsonl
╭─ Modal Deprecation Warning (2025-02-24) ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ We have renamed several parameters related to autoscaling. Please update your code to use the following new names:                                                                                                 │
│                                                                                                                                                                                                                    │
│ - container_idle_timeout -> scaledown_window                                                                                                                                                                       │
│                                                                                                                                                                                                                    │
│ See https://modal.com/docs/guide/modal-1-0-migration for more details.                                                                                                                                             │
│                                                                                                                                                                                                                    │
│ Source: /private/tmp/llm-finetuning/src/inference.py:31                                                                                                                                                            │
│   @app.cls(                                                                                                                                                                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Modal Deprecation Warning (2025-04-09) ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ The `allow_concurrent_inputs` parameter is deprecated. Please use the `@modal.concurrent` decorator instead.                                                                                                       │
│                                                                                                                                                                                                                    │
│ See https://modal.com/docs/guide/modal-1-0-migration for more information.                                                                                                                                         │
│                                                                                                                                                                                                                    │
│ Source: /private/tmp/llm-finetuning/src/inference.py:31                                                                                                                                                            │
│   @app.cls(                                                                                                                                                                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Modal Deprecation Warning (2025-03-05) ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ The `@modal.web_endpoint` decorator has been renamed to `@modal.fastapi_endpoint`.                                                                                                                                 │
│                                                                                                                                                                                                                    │
│ Source: /private/tmp/llm-finetuning/src/inference.py:121                                                                                                                                                           │
│   @modal.web_endpoint()                                                                                                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Modal Deprecation Warning (2025-04-15) ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ <class 'src.inference.Inference'> uses a non-default constructor (__init__) method.                                                                                                                                │
│ Custom constructors will not be supported in a a future version of Modal.                                                                                                                                          │
│                                                                                                                                                                                                                    │
│ To parameterize classes, use dataclass-style modal.parameter() declarations instead,                                                                                                                               │
│ e.g.:                                                                                                                                                                                                              │
│                                                                                                                                                                                                                    │
│                                                                                                                                                                                                                    │
│ class Inference:                                                                                                                                                                                                   │
│     model_name: str = modal.parameter()                                                                                                                                                                            │
│                                                                                                                                                                                                                    │
│ More information on class parameterization can be found here: https://modal.com/docs/guide/parametrized-functions                                                                                                  │
│                                                                                                                                                                                                                    │
│ Source: /private/tmp/llm-finetuning/src/inference.py:31                                                                                                                                                            │
│   @app.cls(                                                                                                                                                                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Note that running a local entrypoint in detached mode only keeps the last triggered Modal function alive after the parent process has been killed or disconnected.
✓ Initialized. View run at https://modal.com/apps/davidxia/main/ap-42RBhST6fQERso4ziKY9G0
✓ Created objects.
├── 🔨 Created mount PythonPackage:src
├── 🔨 Created function train.
├── 🔨 Created function preproc_data.
├── 🔨 Created function launch.
├── 🔨 Created function Inference.*.
├── 🔨 Created function merge.
└── 🔨 Created web endpoint for Inference.web => https://davidxia--example-axolotl-inference-web-dev.modal.run
/root/src/inference.py:31: DeprecationError: 2025-02-24: We have renamed several parameters related to autoscaling. Please update your code to use the following new names:

- container_idle_timeout -> scaledown_window

See https://modal.com/docs/guide/modal-1-0-migration for more details.
  @app.cls(
/root/src/inference.py:31: DeprecationError: 2025-04-09: The `allow_concurrent_inputs` parameter is deprecated. Please use the `@modal.concurrent` decorator instead.

See https://modal.com/docs/guide/modal-1-0-migration for more information.
  @app.cls(
/root/src/inference.py:121: DeprecationError: 2025-03-05: The `@modal.web_endpoint` decorator has been renamed to `@modal.fastapi_endpoint`.
  @modal.web_endpoint()
/root/src/inference.py:31: DeprecationError: 2025-04-15:
<class 'src.inference.Inference'> uses a non-default constructor (__init__) method.
Custom constructors will not be supported in a a future version of Modal.

To parameterize classes, use dataclass-style modal.parameter() declarations instead,
e.g.:


class Inference:
    model_name: str = modal.parameter()

More information on class parameterization can be found here: https://modal.com/docs/guide/parametrized-functions

  @app.cls(
Volume contains mistralai/Mistral-7B-v0.1.
Preparing training run in /runs/axo-2025-05-02-13-12-18-b48c.
Spawning container for data preprocessing.
/root/src/inference.py:31: DeprecationError: 2025-02-24: We have renamed several parameters related to autoscaling. Please update your code to use the following new names:

- container_idle_timeout -> scaledown_window

See https://modal.com/docs/guide/modal-1-0-migration for more details.
  @app.cls(
/root/src/inference.py:31: DeprecationError: 2025-04-09: The `allow_concurrent_inputs` parameter is deprecated. Please use the `@modal.concurrent` decorator instead.

See https://modal.com/docs/guide/modal-1-0-migration for more information.
  @app.cls(
/root/src/inference.py:121: DeprecationError: 2025-03-05: The `@modal.web_endpoint` decorator has been renamed to `@modal.fastapi_endpoint`.
  @modal.web_endpoint()
/root/src/inference.py:31: DeprecationError: 2025-04-15:
<class 'src.inference.Inference'> uses a non-default constructor (__init__) method.
Custom constructors will not be supported in a a future version of Modal.

To parameterize classes, use dataclass-style modal.parameter() declarations instead,
e.g.:


class Inference:
    model_name: str = modal.parameter()

More information on class parameterization can be found here: https://modal.com/docs/guide/parametrized-functions

  @app.cls(
Preprocessing data.
WARNING: BNB_CUDA_VERSION=121 environment variable detected; loading libbitsandbytes_cuda121.so.
This can be used to load a bitsandbytes version that is different from the PyTorch CUDA version.
If this was unintended set the BNB_CUDA_VERSION variable to an empty string: export BNB_CUDA_VERSION=
If you use the manual override make sure the right libcudart.so is in your LD_LIBRARY_PATH
For example by adding the following to your .bashrc: export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path_to_cuda_dir/lib64

[2025-05-02 13:12:29,003] [INFO] [datasets.<module>:58] [PID:4] PyTorch version 2.3.0+cu121 available.
[2025-05-02 13:12:30,385] [INFO] [real_accelerator.py:203:get_accelerator] Setting ds_accelerator to cuda (auto detect)
df: /root/.triton/autotune: No such file or directory
[2025-05-02 13:12:30,490] [INFO] [root.spawn:38] [PID:4] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -g0 -fPIC -g0 -c /tmp/tmprwxyx1wn/test.c -o /tmp/tmprwxyx1wn/test.o
[2025-05-02 13:12:30,535] [INFO] [root.spawn:38] [PID:4] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat /tmp/tmprwxyx1wn/test.o -laio -o /tmp/tmprwxyx1wn/a.out
 [WARNING]  Please specify the CUTLASS repo directory as environment variable $CUTLASS_PATH
 [WARNING]  sparse_attn requires a torch version >= 1.5 and < 2.0 but detected 2.3
 [WARNING]  using untested triton version (2.3.0), only 1.0.0 is known to be compatible
                                 dP            dP   dP
                                 88            88   88
      .d8888b. dP.  .dP .d8888b. 88 .d8888b. d8888P 88
      88'  `88  `8bd8'  88'  `88 88 88'  `88   88   88
      88.  .88  .d88b.  88.  .88 88 88.  .88   88   88
      `88888P8 dP'  `dP `88888P' dP `88888P'   dP   dP



****************************************
**** Axolotl Dependency Versions *****
  accelerate: 0.30.1
        peft: 0.11.1
transformers: 4.42.3
         trl: 0.8.7.dev0
       torch: 2.3.0+cu121
bitsandbytes: 0.43.1
****************************************
[2025-05-02 13:12:32,791] [WARNING] [axolotl.utils.config.models.input.hint_lora_8bit:1004] [PID:4] [RANK:0] We recommend setting `load_in_8bit: true` for LORA finetuning
[2025-05-02 13:12:32,791] [DEBUG] [axolotl.normalize_config:80] [PID:4] [RANK:0] bf16 support detected, enabling for this configuration.
[2025-05-02 13:12:32,874] [INFO] [axolotl.normalize_config:183] [PID:4] [RANK:0] GPU memory usage baseline: 0.000GB (+0.422GB misc)
[2025-05-02 13:12:33,193] [DEBUG] [axolotl.load_tokenizer:280] [PID:4] [RANK:0] EOS: 2 / </s>
[2025-05-02 13:12:33,193] [DEBUG] [axolotl.load_tokenizer:281] [PID:4] [RANK:0] BOS: 1 / <s>
[2025-05-02 13:12:33,193] [DEBUG] [axolotl.load_tokenizer:282] [PID:4] [RANK:0] PAD: 2 / </s>
[2025-05-02 13:12:33,193] [DEBUG] [axolotl.load_tokenizer:283] [PID:4] [RANK:0] UNK: 0 / <unk>
[2025-05-02 13:12:33,193] [INFO] [axolotl.load_tokenizer:294] [PID:4] [RANK:0] No Chat template selected. Consider adding a chat template for easier inference.
[2025-05-02 13:12:33,194] [INFO] [axolotl.load_tokenized_prepared_datasets:183] [PID:4] [RANK:0] Unable to find prepared dataset in last_run_prepared/9023488e38c3be97fecc9d9fd38f77c5
[2025-05-02 13:12:33,194] [INFO] [axolotl.load_tokenized_prepared_datasets:184] [PID:4] [RANK:0] Loading raw datasets...
[2025-05-02 13:12:33,194] [INFO] [axolotl.load_tokenized_prepared_datasets:193] [PID:4] [RANK:0] No seed provided, using default seed of 42
[2025-05-02 13:12:33,332] [INFO] [axolotl.get_dataset_wrapper:540] [PID:4] [RANK:0] Loading dataset with base_type: None and prompt_style: None
[2025-05-02 13:12:34,973] [INFO] [axolotl.load_tokenized_prepared_datasets:414] [PID:4] [RANK:0] merging datasets
[2025-05-02 13:12:34,979] [DEBUG] [axolotl.process_datasets_for_packing:188] [PID:4] [RANK:0] min_input_len: 41
[2025-05-02 13:12:34,980] [DEBUG] [axolotl.process_datasets_for_packing:190] [PID:4] [RANK:0] max_input_len: 379
[2025-05-02 13:12:34,980] [INFO] [axolotl.process_datasets_for_packing:195] [PID:4] [RANK:0] dropping attention_mask column
[2025-05-02 13:12:36,112] [INFO] [axolotl.load_tokenized_prepared_datasets:427] [PID:4] [RANK:0] Saving merged prepared dataset to disk... last_run_prepared/9023488e38c3be97fecc9d9fd38f77c5
[2025-05-02 13:12:36,179] [DEBUG] [axolotl.calculate_total_num_steps:299] [PID:4] [RANK:0] total_num_tokens: 412_586
[2025-05-02 13:12:36,206] [DEBUG] [axolotl.calculate_total_num_steps:312] [PID:4] [RANK:0] `total_supervised_tokens: 164_809`
[2025-05-02 13:12:36,206] [DEBUG] [axolotl.calculate_total_num_steps:390] [PID:4] [RANK:0] total_num_steps: 238
[2025-05-02 13:12:39,488] [INFO] [axolotl.cli.preprocess.do_cli:82] [PID:4] [RANK:0] Success! Preprocessed data path: `dataset_prepared_path: last_run_prepared`
Spawning container for training.
/root/src/inference.py:31: DeprecationError: 2025-02-24: We have renamed several parameters related to autoscaling. Please update your code to use the following new names:

- container_idle_timeout -> scaledown_window

See https://modal.com/docs/guide/modal-1-0-migration for more details.
  @app.cls(
/root/src/inference.py:31: DeprecationError: 2025-04-09: The `allow_concurrent_inputs` parameter is deprecated. Please use the `@modal.concurrent` decorator instead.

See https://modal.com/docs/guide/modal-1-0-migration for more information.
  @app.cls(
/root/src/inference.py:121: DeprecationError: 2025-03-05: The `@modal.web_endpoint` decorator has been renamed to `@modal.fastapi_endpoint`.
  @modal.web_endpoint()
/root/src/inference.py:31: DeprecationError: 2025-04-15:
<class 'src.inference.Inference'> uses a non-default constructor (__init__) method.
Custom constructors will not be supported in a a future version of Modal.

To parameterize classes, use dataclass-style modal.parameter() declarations instead,
e.g.:


class Inference:
    model_name: str = modal.parameter()

More information on class parameterization can be found here: https://modal.com/docs/guide/parametrized-functions

  @app.cls(
Starting training run in /runs/axo-2025-05-02-13-12-18-b48c.
Using 2 NVIDIA A100-SXM4-40GB GPU(s).
The following values were not passed to `accelerate launch` and had defaults used instead:
        `--num_processes` was set to a value of `2`
                More than one GPU was found, enabling multi-GPU training.
                If this was unintended please pass in `--num_processes=1`.
        `--num_machines` was set to a value of `1`
        `--mixed_precision` was set to a value of `'no'`
        `--dynamo_backend` was set to a value of `'no'`
To avoid this warning pass in values for each of the problematic parameters or run `accelerate config`.
...
```
</details>


<details>
<summary>after</summary>

```bash
$ modal run --detach -m src.train --config=config/mistral.yml --data=data/sqlqa.jsonl
Note that running a local entrypoint in detached mode only keeps the last triggered Modal function alive after the parent process has been killed or disconnected.
✓ Initialized. View run at https://modal.com/apps/davidxia/main/ap-3OUD1LsVH6HRjvF87rusVH
✓ Created objects.
├── 🔨 Created mount PythonPackage:src
├── 🔨 Created function train.
├── 🔨 Created function preproc_data.
├── 🔨 Created function launch.
├── 🔨 Created function Inference.*.
├── 🔨 Created function merge.
└── 🔨 Created web endpoint for Inference.web => https://davidxia--example-axolotl-inference-web-dev.modal.run
Volume contains mistralai/Mistral-7B-v0.1.
Preparing training run in /runs/axo-2025-05-02-12-37-37-8a2a.
Spawning container for data preprocessing.
Preprocessing data.
WARNING: BNB_CUDA_VERSION=121 environment variable detected; loading libbitsandbytes_cuda121.so.
This can be used to load a bitsandbytes version that is different from the PyTorch CUDA version.
If this was unintended set the BNB_CUDA_VERSION variable to an empty string: export BNB_CUDA_VERSION=
If you use the manual override make sure the right libcudart.so is in your LD_LIBRARY_PATH
For example by adding the following to your .bashrc: export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path_to_cuda_dir/lib64

[2025-05-02 12:37:52,022] [INFO] [datasets.<module>:58] [PID:4] PyTorch version 2.3.0+cu121 available.
[2025-05-02 12:37:53,545] [INFO] [real_accelerator.py:203:get_accelerator] Setting ds_accelerator to cuda (auto detect)
df: /root/.triton/autotune: No such file or directory
[2025-05-02 12:37:53,804] [INFO] [root.spawn:38] [PID:4] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -g0 -fPIC -g0 -c /tmp/tmp0f02zxj4/test.c -o /tmp/tmp0f02zxj4/test.o
[2025-05-02 12:37:53,861] [INFO] [root.spawn:38] [PID:4] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat /tmp/tmp0f02zxj4/test.o -laio -o /tmp/tmp0f02zxj4/a.out
 [WARNING]  Please specify the CUTLASS repo directory as environment variable $CUTLASS_PATH
 [WARNING]  sparse_attn requires a torch version >= 1.5 and < 2.0 but detected 2.3
 [WARNING]  using untested triton version (2.3.0), only 1.0.0 is known to be compatible
                                 dP            dP   dP
                                 88            88   88
      .d8888b. dP.  .dP .d8888b. 88 .d8888b. d8888P 88
      88'  `88  `8bd8'  88'  `88 88 88'  `88   88   88
      88.  .88  .d88b.  88.  .88 88 88.  .88   88   88
      `88888P8 dP'  `dP `88888P' dP `88888P'   dP   dP



****************************************
**** Axolotl Dependency Versions *****
  accelerate: 0.30.1
        peft: 0.11.1
transformers: 4.42.3
         trl: 0.8.7.dev0
       torch: 2.3.0+cu121
bitsandbytes: 0.43.1
****************************************
[2025-05-02 12:37:56,174] [WARNING] [axolotl.utils.config.models.input.hint_lora_8bit:1004] [PID:4] [RANK:0] We recommend setting `load_in_8bit: true` for LORA finetuning
[2025-05-02 12:37:56,175] [DEBUG] [axolotl.normalize_config:80] [PID:4] [RANK:0] bf16 support detected, enabling for this configuration.
[2025-05-02 12:37:56,259] [INFO] [axolotl.normalize_config:183] [PID:4] [RANK:0] GPU memory usage baseline: 0.000GB (+0.422GB misc)
[2025-05-02 12:37:56,530] [DEBUG] [axolotl.load_tokenizer:280] [PID:4] [RANK:0] EOS: 2 / </s>
[2025-05-02 12:37:56,530] [DEBUG] [axolotl.load_tokenizer:281] [PID:4] [RANK:0] BOS: 1 / <s>
[2025-05-02 12:37:56,530] [DEBUG] [axolotl.load_tokenizer:282] [PID:4] [RANK:0] PAD: 2 / </s>
[2025-05-02 12:37:56,530] [DEBUG] [axolotl.load_tokenizer:283] [PID:4] [RANK:0] UNK: 0 / <unk>
[2025-05-02 12:37:56,530] [INFO] [axolotl.load_tokenizer:294] [PID:4] [RANK:0] No Chat template selected. Consider adding a chat template for easier inference.
[2025-05-02 12:37:56,531] [INFO] [axolotl.load_tokenized_prepared_datasets:183] [PID:4] [RANK:0] Unable to find prepared dataset in last_run_prepared/9023488e38c3be97fecc9d9fd38f77c5
[2025-05-02 12:37:56,531] [INFO] [axolotl.load_tokenized_prepared_datasets:184] [PID:4] [RANK:0] Loading raw datasets...
[2025-05-02 12:37:56,531] [INFO] [axolotl.load_tokenized_prepared_datasets:193] [PID:4] [RANK:0] No seed provided, using default seed of 42
[2025-05-02 12:37:56,666] [INFO] [axolotl.get_dataset_wrapper:540] [PID:4] [RANK:0] Loading dataset with base_type: None and prompt_style: None
[2025-05-02 12:37:58,171] [INFO] [axolotl.load_tokenized_prepared_datasets:414] [PID:4] [RANK:0] merging datasets
[2025-05-02 12:37:58,179] [DEBUG] [axolotl.process_datasets_for_packing:188] [PID:4] [RANK:0] min_input_len: 41
[2025-05-02 12:37:58,180] [DEBUG] [axolotl.process_datasets_for_packing:190] [PID:4] [RANK:0] max_input_len: 379
[2025-05-02 12:37:58,180] [INFO] [axolotl.process_datasets_for_packing:195] [PID:4] [RANK:0] dropping attention_mask column
[2025-05-02 12:37:59,277] [INFO] [axolotl.load_tokenized_prepared_datasets:427] [PID:4] [RANK:0] Saving merged prepared dataset to disk... last_run_prepared/9023488e38c3be97fecc9d9fd38f77c5
[2025-05-02 12:37:59,363] [DEBUG] [axolotl.calculate_total_num_steps:299] [PID:4] [RANK:0] total_num_tokens: 412_586
[2025-05-02 12:37:59,390] [DEBUG] [axolotl.calculate_total_num_steps:312] [PID:4] [RANK:0] `total_supervised_tokens: 164_809`
[2025-05-02 12:37:59,390] [DEBUG] [axolotl.calculate_total_num_steps:390] [PID:4] [RANK:0] total_num_steps: 238
[2025-05-02 12:38:02,873] [INFO] [axolotl.cli.preprocess.do_cli:82] [PID:4] [RANK:0] Success! Preprocessed data path: `dataset_prepared_path: last_run_prepared`
Spawning container for training.
Starting training run in /runs/axo-2025-05-02-12-37-37-8a2a.
Using 2 NVIDIA A100-SXM4-40GB GPU(s).
The following values were not passed to `accelerate launch` and had defaults used instead:
                More than one GPU was found, enabling multi-GPU training.
                If this was unintended please pass in `--num_processes=1`.
To avoid this warning pass in values for each of the problematic parameters or run `accelerate config`.
WARNING: BNB_CUDA_VERSION=121 environment variable detected; loading libbitsandbytes_cuda121.so.
This can be used to load a bitsandbytes version that is different from the PyTorch CUDA version.
If this was unintended set the BNB_CUDA_VERSION variable to an empty string: export BNB_CUDA_VERSION=
If you use the manual override make sure the right libcudart.so is in your LD_LIBRARY_PATH
For example by adding the following to your .bashrc: export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path_to_cuda_dir/lib64

WARNING: BNB_CUDA_VERSION=121 environment variable detected; loading libbitsandbytes_cuda121.so.
This can be used to load a bitsandbytes version that is different from the PyTorch CUDA version.
If this was unintended set the BNB_CUDA_VERSION variable to an empty string: export BNB_CUDA_VERSION=
If you use the manual override make sure the right libcudart.so is in your LD_LIBRARY_PATH
For example by adding the following to your .bashrc: export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path_to_cuda_dir/lib64

[2025-05-02 12:38:23,101] [INFO] [datasets.<module>:58] [PID:12] PyTorch version 2.3.0+cu121 available.
[2025-05-02 12:38:23,102] [INFO] [datasets.<module>:58] [PID:13] PyTorch version 2.3.0+cu121 available.
[2025-05-02 12:38:24,976] [INFO] [real_accelerator.py:203:get_accelerator] Setting ds_accelerator to cuda (auto detect)
[2025-05-02 12:38:24,976] [INFO] [real_accelerator.py:203:get_accelerator] Setting ds_accelerator to cuda (auto detect)
df: /root/.triton/autotune: No such file or directory
df: /root/.triton/autotune: No such file or directory
[2025-05-02 12:38:25,145] [INFO] [root.spawn:38] [PID:12] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -g0 -fPIC -g0 -c /tmp/tmpsnfwgz_6/test.c -o /tmp/tmpsnfwgz_6/test.o
[2025-05-02 12:38:25,146] [INFO] [root.spawn:38] [PID:13] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -g0 -fPIC -g0 -c /tmp/tmpdgqkot_h/test.c -o /tmp/tmpdgqkot_h/test.o
[2025-05-02 12:38:25,202] [INFO] [root.spawn:38] [PID:13] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat /tmp/tmpdgqkot_h/test.o -laio -o /tmp/tmpdgqkot_h/a.out
[2025-05-02 12:38:25,203] [INFO] [root.spawn:38] [PID:12] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat /tmp/tmpsnfwgz_6/test.o -laio -o /tmp/tmpsnfwgz_6/a.out
 [WARNING]  Please specify the CUTLASS repo directory as environment variable $CUTLASS_PATH
 [WARNING]  Please specify the CUTLASS repo directory as environment variable $CUTLASS_PATH
 [WARNING]  sparse_attn requires a torch version >= 1.5 and < 2.0 but detected 2.3
 [WARNING]  using untested triton version (2.3.0), only 1.0.0 is known to be compatible
 [WARNING]  sparse_attn requires a torch version >= 1.5 and < 2.0 but detected 2.3
 [WARNING]  using untested triton version (2.3.0), only 1.0.0 is known to be compatible
[2025-05-02 12:38:28,058] [WARNING] [axolotl.utils.config.models.input.hint_lora_8bit:1004] [PID:13] [RANK:1] We recommend setting `load_in_8bit: true` for LORA finetuning
[2025-05-02 12:38:28,059] [DEBUG] [axolotl.normalize_config:80] [PID:13] [RANK:1] bf16 support detected, enabling for this configuration.
[2025-05-02 12:38:28,060] [WARNING] [axolotl.utils.config.models.input.hint_lora_8bit:1004] [PID:12] [RANK:0] We recommend setting `load_in_8bit: true` for LORA finetuning
[2025-05-02 12:38:28,060] [DEBUG] [axolotl.normalize_config:80] [PID:12] [RANK:0] bf16 support detected, enabling for this configuration.
[2025-05-02 12:38:28,126] [INFO] [axolotl.normalize_config:183] [PID:13] [RANK:1] GPU memory usage baseline: 0.000GB (+0.509GB misc)
[2025-05-02 12:38:28,130] [INFO] [comm.py:637:init_distributed] cdb=None
[2025-05-02 12:38:28,304] [INFO] [axolotl.normalize_config:183] [PID:12] [RANK:0] GPU memory usage baseline: 0.000GB (+0.509GB misc)
[2025-05-02 12:38:28,307] [INFO] [comm.py:637:init_distributed] cdb=None
[2025-05-02 12:38:28,307] [INFO] [comm.py:668:init_distributed] Initializing TorchBackend in DeepSpeed with backend nccl
                                 dP            dP   dP
                                 88            88   88
      .d8888b. dP.  .dP .d8888b. 88 .d8888b. d8888P 88
      88'  `88  `8bd8'  88'  `88 88 88'  `88   88   88
      88.  .88  .d88b.  88.  .88 88 88.  .88   88   88
      `88888P8 dP'  `dP `88888P' dP `88888P'   dP   dP



****************************************
**** Axolotl Dependency Versions *****
  accelerate: 0.30.1
        peft: 0.11.1
transformers: 4.42.3
         trl: 0.8.7.dev0
       torch: 2.3.0+cu121
bitsandbytes: 0.43.1
****************************************
[2025-05-02 12:38:28,612] [DEBUG] [axolotl.load_tokenizer:280] [PID:12] [RANK:0] EOS: 2 / </s>
[2025-05-02 12:38:28,612] [DEBUG] [axolotl.load_tokenizer:281] [PID:12] [RANK:0] BOS: 1 / <s>
[2025-05-02 12:38:28,612] [DEBUG] [axolotl.load_tokenizer:282] [PID:12] [RANK:0] PAD: 2 / </s>
[2025-05-02 12:38:28,612] [DEBUG] [axolotl.load_tokenizer:283] [PID:12] [RANK:0] UNK: 0 / <unk>
[2025-05-02 12:38:28,612] [INFO] [axolotl.load_tokenizer:294] [PID:12] [RANK:0] No Chat template selected. Consider adding a chat template for easier inference.
[2025-05-02 12:38:28,613] [INFO] [axolotl.load_tokenized_prepared_datasets:179] [PID:12] [RANK:0] Loading prepared dataset from disk at last_run_prepared/9023488e38c3be97fecc9d9fd38f77c5...
[2025-05-02 12:38:28,679] [DEBUG] [axolotl.load_tokenizer:280] [PID:13] [RANK:1] EOS: 2 / </s>
[2025-05-02 12:38:28,680] [DEBUG] [axolotl.load_tokenizer:281] [PID:13] [RANK:1] BOS: 1 / <s>
[2025-05-02 12:38:28,680] [DEBUG] [axolotl.load_tokenizer:282] [PID:13] [RANK:1] PAD: 2 / </s>
[2025-05-02 12:38:28,680] [DEBUG] [axolotl.load_tokenizer:283] [PID:13] [RANK:1] UNK: 0 / <unk>
[2025-05-02 12:38:28,680] [INFO] [axolotl.load_tokenizer:294] [PID:13] [RANK:1] No Chat template selected. Consider adding a chat template for easier inference.
[2025-05-02 12:38:28,771] [INFO] [axolotl.load_tokenized_prepared_datasets:181] [PID:12] [RANK:0] Prepared dataset loaded from disk...
[2025-05-02 12:38:29,792] [INFO] [axolotl.load_tokenized_prepared_datasets:179] [PID:13] [RANK:1] Loading prepared dataset from disk at last_run_prepared/9023488e38c3be97fecc9d9fd38f77c5...
[2025-05-02 12:38:29,798] [DEBUG] [axolotl.calculate_total_num_steps:299] [PID:12] [RANK:0] total_num_tokens: 391_558
[2025-05-02 12:38:29,798] [INFO] [axolotl.load_tokenized_prepared_datasets:181] [PID:13] [RANK:1] Prepared dataset loaded from disk...
[2025-05-02 12:38:29,824] [DEBUG] [axolotl.calculate_total_num_steps:312] [PID:12] [RANK:0] `total_supervised_tokens: 156_103`
[2025-05-02 12:38:29,824] [DEBUG] [axolotl.calculate_total_num_steps:390] [PID:12] [RANK:0] total_num_steps: 119
[2025-05-02 12:38:29,828] [DEBUG] [axolotl.train.train:56] [PID:12] [RANK:0] loading tokenizer... mistralai/Mistral-7B-v0.1
[2025-05-02 12:38:30,033] [DEBUG] [axolotl.load_tokenizer:280] [PID:13] [RANK:1] EOS: 2 / </s>
[2025-05-02 12:38:30,033] [DEBUG] [axolotl.load_tokenizer:281] [PID:13] [RANK:1] BOS: 1 / <s>
[2025-05-02 12:38:30,033] [DEBUG] [axolotl.load_tokenizer:282] [PID:13] [RANK:1] PAD: 2 / </s>
[2025-05-02 12:38:30,033] [DEBUG] [axolotl.load_tokenizer:283] [PID:13] [RANK:1] UNK: 0 / <unk>
[2025-05-02 12:38:30,033] [INFO] [axolotl.load_tokenizer:294] [PID:13] [RANK:1] No Chat template selected. Consider adding a chat template for easier inference.
You are attempting to use Flash Attention 2.0 with a model not initialized on GPU. Make sure to move the model to GPU after initializing it on CPU with `model.to('cuda')`.
[2025-05-02 12:38:30,939] [DEBUG] [axolotl.load_tokenizer:280] [PID:12] [RANK:0] EOS: 2 / </s>
[2025-05-02 12:38:30,939] [DEBUG] [axolotl.load_tokenizer:281] [PID:12] [RANK:0] BOS: 1 / <s>
[2025-05-02 12:38:30,940] [DEBUG] [axolotl.load_tokenizer:282] [PID:12] [RANK:0] PAD: 2 / </s>
[2025-05-02 12:38:30,940] [DEBUG] [axolotl.load_tokenizer:283] [PID:12] [RANK:0] UNK: 0 / <unk>
[2025-05-02 12:38:30,940] [INFO] [axolotl.load_tokenizer:294] [PID:12] [RANK:0] No Chat template selected. Consider adding a chat template for easier inference.
[2025-05-02 12:38:30,940] [DEBUG] [axolotl.train.train:85] [PID:12] [RANK:0] loading model and peft_config...
[2025-05-02 12:38:30,948] [WARNING] [accelerate.utils.other.check_os_kernel:349] [PID:12] Detected kernel version 4.4.0, which is below the recommended minimum of 5.5.0; this can cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher.
You are attempting to use Flash Attention 2.0 with a model not initialized on GPU. Make sure to move the model to GPU after initializing it on CPU with `model.to('cuda')`.
[2025-05-02 12:38:31,610] [INFO] [partition_parameters.py:345:__exit__] finished initializing model - num_params = 291, num_elems = 7.24B
[2025-05-02 12:38:38,948] [INFO] [axolotl.load_model:734] [PID:13] [RANK:1] GPU memory usage after model load: 7.235GB (+10.830GB cache, +1.837GB misc)
[2025-05-02 12:38:38,949] [INFO] [axolotl.load_model:734] [PID:12] [RANK:0] GPU memory usage after model load: 7.235GB (+0.935GB cache, +1.837GB misc)
[2025-05-02 12:38:38,952] [INFO] [axolotl.load_model:794] [PID:13] [RANK:1] converting modules to torch.bfloat16 for flash attention
[2025-05-02 12:38:38,952] [INFO] [axolotl.load_model:794] [PID:12] [RANK:0] converting modules to torch.bfloat16 for flash attention
[2025-05-02 12:38:38,954] [INFO] [axolotl.load_lora:951] [PID:13] [RANK:1] found linear modules: ['gate_proj', 'v_proj', 'o_proj', 'k_proj', 'up_proj', 'down_proj', 'q_proj']
[2025-05-02 12:38:38,954] [INFO] [axolotl.load_lora:951] [PID:12] [RANK:0] found linear modules: ['gate_proj', 'v_proj', 'o_proj', 'k_proj', 'up_proj', 'down_proj', 'q_proj']
trainable params: 304,119,808 || all params: 7,545,884,672 || trainable%: 4.0303
[2025-05-02 12:38:39,570] [INFO] [axolotl.load_model:843] [PID:12] [RANK:0] GPU memory usage after adapters: 7.801GB (+1.427GB cache, +1.837GB misc)
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/training_args.py:1494: FutureWarning: `evaluation_strategy` is deprecated and will be removed in version 4.46 of 🤗 Transformers. Use `eval_strategy` instead
  warnings.warn(
[2025-05-02 12:38:39,612] [INFO] [axolotl.load_model:843] [PID:13] [RANK:1] GPU memory usage after adapters: 7.801GB (+11.322GB cache, +1.837GB misc)
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/training_args.py:1494: FutureWarning: `evaluation_strategy` is deprecated and will be removed in version 4.46 of 🤗 Transformers. Use `eval_strategy` instead
  warnings.warn(
[2025-05-02 12:38:39,625] [WARNING] [accelerate.utils.other.check_os_kernel:349] [PID:12] Detected kernel version 4.4.0, which is below the recommended minimum of 5.5.0; this can cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher.
[2025-05-02 12:38:39,626] [INFO] [axolotl.train.train:119] [PID:12] [RANK:0] Pre-saving adapter config to ./lora-out
[2025-05-02 12:38:39,672] [INFO] [axolotl.train.train:156] [PID:12] [RANK:0] Starting trainer...
Parameter Offload: Total persistent parameters: 1314816 in 129 params
You're using a LlamaTokenizerFast tokenizer. Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to encode the text followed by a call to the `pad` method to get a padded encoding.
You're using a LlamaTokenizerFast tokenizer. Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to encode the text followed by a call to the `pad` method to get a padded encoding.
{'loss': 1.2142, 'grad_norm': 35.72650744734555, 'learning_rate': 1e-05, 'epoch': 0.02}
[2025-05-02 12:38:51,058] [INFO] [axolotl.callbacks.on_step_end:128] [PID:13] [RANK:1] GPU memory usage while training: 9.060GB (+8.307GB cache, +2.583GB misc)
[2025-05-02 12:38:51,059] [INFO] [axolotl.callbacks.on_step_end:128] [PID:12] [RANK:0] GPU memory usage while training: 9.060GB (+8.417GB cache, +2.583GB misc)
{'loss': 1.117, 'grad_norm': 33.218018183595476, 'learning_rate': 2e-05, 'epoch': 0.03}
{'loss': 1.0946, 'grad_norm': 38.290562847354146, 'learning_rate': 3e-05, 'epoch': 0.05}
{'loss': 0.6517, 'grad_norm': 24.066622129949003, 'learning_rate': 4e-05, 'epoch': 0.07}
{'loss': 0.3498, 'grad_norm': 12.037866436279794, 'learning_rate': 5e-05, 'epoch': 0.08}
{'loss': 0.2248, 'grad_norm': 7.25422704022738, 'learning_rate': 6e-05, 'epoch': 0.1}
{'loss': 0.1505, 'grad_norm': 3.708067202596099, 'learning_rate': 7e-05, 'epoch': 0.12}
{'loss': 0.1291, 'grad_norm': 2.8061295627471905, 'learning_rate': 8e-05, 'epoch': 0.13}
{'loss': 0.1143, 'grad_norm': 3.5657503539285664, 'learning_rate': 9e-05, 'epoch': 0.15}
{'loss': 0.1434, 'grad_norm': 3.6199335879825645, 'learning_rate': 0.0001, 'epoch': 0.17}
{'loss': 0.1207, 'grad_norm': 2.59259425276191, 'learning_rate': 9.997960964140947e-05, 'epoch': 0.18}
{'loss': 0.1342, 'grad_norm': 3.6225836772529716, 'learning_rate': 9.991845519630678e-05, 'epoch': 0.2}
{'loss': 0.0932, 'grad_norm': 2.201371960859018, 'learning_rate': 9.981658654313457e-05, 'epoch': 0.22}
{'loss': 0.1182, 'grad_norm': 2.8598576305526606, 'learning_rate': 9.967408676742751e-05, 'epoch': 0.23}
{'loss': 0.1035, 'grad_norm': 2.8575790806770476, 'learning_rate': 9.949107209404665e-05, 'epoch': 0.25}
{'loss': 0.1208, 'grad_norm': 6.532187271824325, 'learning_rate': 9.926769179238466e-05, 'epoch': 0.27}
{'loss': 0.1515, 'grad_norm': 4.6259978028256645, 'learning_rate': 9.900412805461967e-05, 'epoch': 0.28}
{'loss': 0.1209, 'grad_norm': 4.085233875672791, 'learning_rate': 9.870059584711668e-05, 'epoch': 0.3}
{'loss': 0.0851, 'grad_norm': 3.217192646781647, 'learning_rate': 9.835734273509786e-05, 'epoch': 0.32}
{'loss': 0.133, 'grad_norm': 2.577333032928601, 'learning_rate': 9.797464868072488e-05, 'epoch': 0.33}
{'loss': 0.1638, 'grad_norm': 3.9243561377347564, 'learning_rate': 9.755282581475769e-05, 'epoch': 0.35}
{'loss': 0.1117, 'grad_norm': 3.067680397898101, 'learning_rate': 9.709221818197624e-05, 'epoch': 0.37}
{'loss': 0.0923, 'grad_norm': 2.383980345174379, 'learning_rate': 9.659320146057262e-05, 'epoch': 0.38}
{'loss': 0.0981, 'grad_norm': 2.0199484401564374, 'learning_rate': 9.60561826557425e-05, 'epoch': 0.4}
{'loss': 0.0879, 'grad_norm': 1.8279883501331209, 'learning_rate': 9.548159976772592e-05, 'epoch': 0.42}
{'loss': 0.0962, 'grad_norm': 2.103906981071679, 'learning_rate': 9.486992143456792e-05, 'epoch': 0.43}
{'loss': 0.0832, 'grad_norm': 2.2033871606840623, 'learning_rate': 9.422164654989072e-05, 'epoch': 0.45}
{'loss': 0.0875, 'grad_norm': 2.0279166877466186, 'learning_rate': 9.353730385598887e-05, 'epoch': 0.47}
{'loss': 0.0781, 'grad_norm': 2.3443314141978884, 'learning_rate': 9.281745151257946e-05, 'epoch': 0.48}
{'loss': 0.0787, 'grad_norm': 10.746351508635772, 'learning_rate': 9.206267664155907e-05, 'epoch': 0.5}
{'loss': 0.1008, 'grad_norm': 7.212365770700587, 'learning_rate': 9.12735948481387e-05, 'epoch': 0.52}
{'loss': 0.087, 'grad_norm': 14.958441912749135, 'learning_rate': 9.045084971874738e-05, 'epoch': 0.53}
{'loss': 0.0938, 'grad_norm': 6.688664607990031, 'learning_rate': 8.959511229611376e-05, 'epoch': 0.55}
{'loss': 0.1106, 'grad_norm': 3.9138025429871117, 'learning_rate': 8.870708053195413e-05, 'epoch': 0.57}
{'loss': 0.0756, 'grad_norm': 3.056258619540342, 'learning_rate': 8.778747871771292e-05, 'epoch': 0.58}
{'loss': 0.0993, 'grad_norm': 2.1279478046677034, 'learning_rate': 8.683705689382024e-05, 'epoch': 0.6}
{'loss': 0.0564, 'grad_norm': 1.8935668515466553, 'learning_rate': 8.585659023794818e-05, 'epoch': 0.62}
{'loss': 0.0768, 'grad_norm': 2.166620566653331, 'learning_rate': 8.484687843276469e-05, 'epoch': 0.63}
{'loss': 0.0855, 'grad_norm': 1.883427010456382, 'learning_rate': 8.380874501370097e-05, 'epoch': 0.65}
{'loss': 0.0509, 'grad_norm': 1.6384865260893726, 'learning_rate': 8.274303669726426e-05, 'epoch': 0.67}
{'loss': 0.0829, 'grad_norm': 1.3946925341464458, 'learning_rate': 8.165062269044353e-05, 'epoch': 0.68}
{'loss': 0.0693, 'grad_norm': 2.0987723737627393, 'learning_rate': 8.053239398177191e-05, 'epoch': 0.7}
{'loss': 0.075, 'grad_norm': 2.582284700666343, 'learning_rate': 7.938926261462366e-05, 'epoch': 0.72}
{'loss': 0.0586, 'grad_norm': 2.0092922770745547, 'learning_rate': 7.822216094333847e-05, 'epoch': 0.73}
{'loss': 0.0651, 'grad_norm': 1.7536333077412807, 'learning_rate': 7.703204087277988e-05, 'epoch': 0.75}
{'loss': 0.0879, 'grad_norm': 1.9634713966335207, 'learning_rate': 7.58198730819481e-05, 'epoch': 0.77}
{'loss': 0.0715, 'grad_norm': 3.277998577486315, 'learning_rate': 7.45866462322802e-05, 'epoch': 0.78}
{'loss': 0.0867, 'grad_norm': 1.9953339937697971, 'learning_rate': 7.333336616128369e-05, 'epoch': 0.8}
{'loss': 0.0688, 'grad_norm': 2.4255042674758536, 'learning_rate': 7.206105506216106e-05, 'epoch': 0.82}
{'loss': 0.0741, 'grad_norm': 2.4906721205415265, 'learning_rate': 7.077075065009433e-05, 'epoch': 0.83}
{'loss': 0.0481, 'grad_norm': 1.7635279736610305, 'learning_rate': 6.946350531586959e-05, 'epoch': 0.85}
{'loss': 0.0752, 'grad_norm': 1.4953617112650974, 'learning_rate': 6.814038526753205e-05, 'epoch': 0.87}
{'loss': 0.0589, 'grad_norm': 1.4568772784696138, 'learning_rate': 6.680246966077151e-05, 'epoch': 0.88}
{'loss': 0.0691, 'grad_norm': 1.5774630740842845, 'learning_rate': 6.545084971874738e-05, 'epoch': 0.9}
{'loss': 0.0759, 'grad_norm': 2.424112051297378, 'learning_rate': 6.408662784207149e-05, 'epoch': 0.92}
{'loss': 0.0525, 'grad_norm': 1.0970305509712466, 'learning_rate': 6.271091670967436e-05, 'epoch': 0.93}
{'loss': 0.0489, 'grad_norm': 1.1919986574835721, 'learning_rate': 6.132483837128823e-05, 'epoch': 0.95}
{'loss': 0.078, 'grad_norm': 2.1273067924080062, 'learning_rate': 5.992952333228728e-05, 'epoch': 0.97}
{'loss': 0.0651, 'grad_norm': 1.4325861445177743, 'learning_rate': 5.85261096316312e-05, 'epoch': 0.98}
{'loss': 0.0487, 'grad_norm': 1.2114852812797878, 'learning_rate': 5.7115741913664264e-05, 'epoch': 1.0}
{'eval_loss': 0.09007035940885544, 'eval_runtime': 3.4118, 'eval_samples_per_second': 58.621, 'eval_steps_per_second': 1.172, 'epoch': 1.0}
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/peft/utils/save_and_load.py:209: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'loss': 0.0389, 'grad_norm': 1.2199608260171368, 'learning_rate': 5.569957049452703e-05, 'epoch': 1.02}
{'loss': 0.0283, 'grad_norm': 0.862214602538543, 'learning_rate': 5.427875042394199e-05, 'epoch': 1.03}
{'loss': 0.0493, 'grad_norm': 1.4915904874219301, 'learning_rate': 5.2854440543138406e-05, 'epoch': 1.05}
{'loss': 0.0385, 'grad_norm': 1.673663610691391, 'learning_rate': 5.142780253968481e-05, 'epoch': 1.07}
{'loss': 0.0457, 'grad_norm': 1.0773093900465893, 'learning_rate': 5e-05, 'epoch': 1.08}
{'loss': 0.0468, 'grad_norm': 1.7011131328226807, 'learning_rate': 4.85721974603152e-05, 'epoch': 1.1}
{'loss': 0.0387, 'grad_norm': 1.1996606789815842, 'learning_rate': 4.71455594568616e-05, 'epoch': 1.12}
{'loss': 0.0369, 'grad_norm': 1.3513211468363024, 'learning_rate': 4.5721249576058027e-05, 'epoch': 1.13}
{'loss': 0.0367, 'grad_norm': 1.327813151995355, 'learning_rate': 4.4300429505472976e-05, 'epoch': 1.15}
{'loss': 0.0349, 'grad_norm': 1.263685547369345, 'learning_rate': 4.288425808633575e-05, 'epoch': 1.17}
{'loss': 0.0341, 'grad_norm': 0.9284676376042686, 'learning_rate': 4.147389036836881e-05, 'epoch': 1.18}
{'loss': 0.0424, 'grad_norm': 2.05140925409097, 'learning_rate': 4.007047666771274e-05, 'epoch': 1.2}
{'loss': 0.0428, 'grad_norm': 0.8789900576065218, 'learning_rate': 3.8675161628711776e-05, 'epoch': 1.22}
{'loss': 0.0301, 'grad_norm': 1.3851313713799622, 'learning_rate': 3.728908329032567e-05, 'epoch': 1.23}
{'loss': 0.0499, 'grad_norm': 1.1254302714475641, 'learning_rate': 3.591337215792852e-05, 'epoch': 1.25}
{'loss': 0.039, 'grad_norm': 1.2167796415450376, 'learning_rate': 3.4549150281252636e-05, 'epoch': 1.27}
{'loss': 0.0506, 'grad_norm': 4.452874722918433, 'learning_rate': 3.3197530339228487e-05, 'epoch': 1.28}
{'loss': 0.0276, 'grad_norm': 0.9299505919258111, 'learning_rate': 3.1859614732467954e-05, 'epoch': 1.3}
{'loss': 0.0421, 'grad_norm': 7.697287947328512, 'learning_rate': 3.053649468413043e-05, 'epoch': 1.32}
{'loss': 0.0285, 'grad_norm': 1.3604883872622895, 'learning_rate': 2.9229249349905684e-05, 'epoch': 1.33}
{'loss': 0.0359, 'grad_norm': 1.37049367616969, 'learning_rate': 2.7938944937838923e-05, 'epoch': 1.35}
{'loss': 0.0369, 'grad_norm': 1.2314236200435549, 'learning_rate': 2.6666633838716314e-05, 'epoch': 1.37}
{'loss': 0.0312, 'grad_norm': 1.061109297078815, 'learning_rate': 2.5413353767719805e-05, 'epoch': 1.38}
{'loss': 0.0455, 'grad_norm': 1.3768483185346843, 'learning_rate': 2.418012691805191e-05, 'epoch': 1.4}
{'loss': 0.0332, 'grad_norm': 0.8345831520768111, 'learning_rate': 2.296795912722014e-05, 'epoch': 1.42}
{'loss': 0.0289, 'grad_norm': 1.0510257090004664, 'learning_rate': 2.1777839056661554e-05, 'epoch': 1.43}
{'loss': 0.0417, 'grad_norm': 1.8998287323444785, 'learning_rate': 2.061073738537635e-05, 'epoch': 1.45}
{'loss': 0.0307, 'grad_norm': 14.561893186403363, 'learning_rate': 1.946760601822809e-05, 'epoch': 1.47}
{'loss': 0.0369, 'grad_norm': 1.0257730351724281, 'learning_rate': 1.8349377309556486e-05, 'epoch': 1.48}
{'loss': 0.0353, 'grad_norm': 1.3772841721276396, 'learning_rate': 1.725696330273575e-05, 'epoch': 1.5}
{'loss': 0.0335, 'grad_norm': 1.2810235754065236, 'learning_rate': 1.619125498629904e-05, 'epoch': 1.52}
{'loss': 0.0279, 'grad_norm': 1.0084202095978663, 'learning_rate': 1.5153121567235335e-05, 'epoch': 1.53}
{'loss': 0.0454, 'grad_norm': 1.5097485472896377, 'learning_rate': 1.414340976205183e-05, 'epoch': 1.55}
{'loss': 0.038, 'grad_norm': 0.9256114311534736, 'learning_rate': 1.3162943106179749e-05, 'epoch': 1.57}
{'loss': 0.0322, 'grad_norm': 0.9156959743427593, 'learning_rate': 1.2212521282287092e-05, 'epoch': 1.58}
{'loss': 0.0467, 'grad_norm': 0.8841007335146208, 'learning_rate': 1.1292919468045877e-05, 'epoch': 1.6}
{'loss': 0.0292, 'grad_norm': 0.8662246307627972, 'learning_rate': 1.0404887703886251e-05, 'epoch': 1.62}
{'loss': 0.0253, 'grad_norm': 1.278270823795406, 'learning_rate': 9.549150281252633e-06, 'epoch': 1.63}
{'loss': 0.033, 'grad_norm': 1.0116511151467455, 'learning_rate': 8.7264051518613e-06, 'epoch': 1.65}
{'loss': 0.0253, 'grad_norm': 0.6913898419353406, 'learning_rate': 7.937323358440935e-06, 'epoch': 1.67}
{'loss': 0.0297, 'grad_norm': 1.131490684349754, 'learning_rate': 7.182548487420554e-06, 'epoch': 1.68}
{'loss': 0.0347, 'grad_norm': 0.9953234478497873, 'learning_rate': 6.462696144011149e-06, 'epoch': 1.7}
{'loss': 0.0261, 'grad_norm': 1.674046305716691, 'learning_rate': 5.778353450109286e-06, 'epoch': 1.72}
{'loss': 0.0287, 'grad_norm': 0.7710538152942155, 'learning_rate': 5.13007856543209e-06, 'epoch': 1.73}
{'loss': 0.0384, 'grad_norm': 1.2037977441053502, 'learning_rate': 4.5184002322740785e-06, 'epoch': 1.75}
{'loss': 0.0305, 'grad_norm': 1.5401028208263905, 'learning_rate': 3.9438173442575e-06, 'epoch': 1.77}
{'loss': 0.0326, 'grad_norm': 1.079354103029057, 'learning_rate': 3.406798539427386e-06, 'epoch': 1.78}
{'loss': 0.0225, 'grad_norm': 0.9056210368761968, 'learning_rate': 2.9077818180237693e-06, 'epoch': 1.8}
{'loss': 0.0359, 'grad_norm': 1.8215107360930178, 'learning_rate': 2.4471741852423237e-06, 'epoch': 1.82}
{'loss': 0.0362, 'grad_norm': 1.1143408452145267, 'learning_rate': 2.0253513192751373e-06, 'epoch': 1.83}
{'loss': 0.025, 'grad_norm': 0.8368102771104278, 'learning_rate': 1.6426572649021476e-06, 'epoch': 1.85}
{'loss': 0.0349, 'grad_norm': 1.0852671095221744, 'learning_rate': 1.2994041528833266e-06, 'epoch': 1.87}
{'loss': 0.0363, 'grad_norm': 1.9454957411496803, 'learning_rate': 9.958719453803278e-07, 'epoch': 1.88}
{'loss': 0.03, 'grad_norm': 0.9183744865009464, 'learning_rate': 7.323082076153509e-07, 'epoch': 1.9}
{'loss': 0.0333, 'grad_norm': 0.9298887578468857, 'learning_rate': 5.089279059533658e-07, 'epoch': 1.92}
{'loss': 0.0255, 'grad_norm': 0.7973102027352923, 'learning_rate': 3.2591323257248893e-07, 'epoch': 1.93}
{'loss': 0.0476, 'grad_norm': 1.3378119171183356, 'learning_rate': 1.8341345686543332e-07, 'epoch': 1.95}
{'loss': 0.0223, 'grad_norm': 0.7965278178525975, 'learning_rate': 8.15448036932176e-08, 'epoch': 1.97}
{'loss': 0.0253, 'grad_norm': 0.8864274818961432, 'learning_rate': 2.0390358590538504e-08, 'epoch': 1.98}
{'loss': 0.0371, 'grad_norm': 1.1689113959551405, 'learning_rate': 0.0, 'epoch': 2.0}
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/peft/utils/save_and_load.py:209: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'eval_loss': 0.09167994558811188, 'eval_runtime': 3.3903, 'eval_samples_per_second': 58.991, 'eval_steps_per_second': 1.18, 'epoch': 2.0}
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/peft/utils/save_and_load.py:209: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'train_runtime': 431.8527, 'train_samples_per_second': 17.599, 'train_steps_per_second': 0.278, 'train_loss': 0.09710082399348417, 'epoch': 2.0}
[2025-05-02 12:45:55,277] [INFO] [axolotl.train.train:173] [PID:12] [RANK:0] Training Completed!!! Saving pre-trained model to ./lora-out
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/peft/utils/save_and_load.py:209: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/peft/utils/save_and_load.py:209: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
(PeftModelForCausalLM(   (base_model): LoraModel(     (model): MistralForCausalLM(       (model): MistralModel(         (embed_tokens): ModulesToSaveWrapper(           (original_module): Embedding(32004, 4096)           (modules_to_save): ModuleDict(             (default): Embedding(32004, 4096)           )         )         (layers): ModuleList(           (0-31): 32 x MistralDecoderLayer(             (self_attn): MistralFlashAttention2(               (q_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=4096, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=4096, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (k_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=1024, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=1024, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (v_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=1024, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=1024, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (o_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=4096, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=4096, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (rotary_emb): MistralRotaryEmbedding()             )             (mlp): MistralMLP(               (gate_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=14336, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=14336, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (up_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=14336, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=14336, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (down_proj): lora.Linear(                 (base_layer): Linear(in_features=14336, out_features=4096, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=14336, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=4096, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (act_fn): SiLU()             )             (input_layernorm): MistralRMSNorm()             (post_attention_layernorm): MistralRMSNorm()           )         )         (norm): MistralRMSNorm()       )       (lm_head): ModulesToSaveWrapper(         (original_module): Linear(in_features=4096, out_features=32004, bias=False)         (modules_to_save): ModuleDict(           (default): Linear(in_features=4096, out_features=32004, bias=False)         )       )     )   ) ), LlamaTokenizerFast(name_or_path='mistralai/Mistral-7B-v0.1', vocab_size=32000, model_max_length=1000000000000000019884624838656, is_fast=True, padding_side='left', truncation_side='right', special_tokens={'bos_token': '<s>', 'eos_token': '</s>', 'unk_token': '<unk>', 'pad_token': '</s>'}, clean_up_tokenization_spaces=False),  added_tokens_decoder={        0: AddedToken("<unk>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),  1: AddedToken("<s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),    2: AddedToken("</s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),   32000: AddedToken("[INST]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),    32001: AddedToken(" [/INST]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),  32002: AddedToken("[SQL]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),     32003: AddedToken(" [/SQL]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False), })
(PeftModelForCausalLM(   (base_model): LoraModel(     (model): MistralForCausalLM(       (model): MistralModel(         (embed_tokens): ModulesToSaveWrapper(           (original_module): Embedding(32004, 4096)           (modules_to_save): ModuleDict(             (default): Embedding(32004, 4096)           )         )         (layers): ModuleList(           (0-31): 32 x MistralDecoderLayer(             (self_attn): MistralFlashAttention2(               (q_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=4096, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=4096, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (k_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=1024, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=1024, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (v_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=1024, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=1024, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (o_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=4096, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=4096, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (rotary_emb): MistralRotaryEmbedding()             )             (mlp): MistralMLP(               (gate_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=14336, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=14336, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (up_proj): lora.Linear(                 (base_layer): Linear(in_features=4096, out_features=14336, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=4096, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=14336, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (down_proj): lora.Linear(                 (base_layer): Linear(in_features=14336, out_features=4096, bias=False)                 (lora_dropout): ModuleDict(                   (default): Dropout(p=0.05, inplace=False)                 )                 (lora_A): ModuleDict(                   (default): Linear(in_features=14336, out_features=16, bias=False)                 )                 (lora_B): ModuleDict(                   (default): Linear(in_features=16, out_features=4096, bias=False)                 )                 (lora_embedding_A): ParameterDict()                 (lora_embedding_B): ParameterDict()               )               (act_fn): SiLU()             )             (input_layernorm): MistralRMSNorm()             (post_attention_layernorm): MistralRMSNorm()           )         )         (norm): MistralRMSNorm()       )       (lm_head): ModulesToSaveWrapper(         (original_module): Linear(in_features=4096, out_features=32004, bias=False)         (modules_to_save): ModuleDict(           (default): Linear(in_features=4096, out_features=32004, bias=False)         )       )     )   ) ), LlamaTokenizerFast(name_or_path='mistralai/Mistral-7B-v0.1', vocab_size=32000, model_max_length=1000000000000000019884624838656, is_fast=True, padding_side='left', truncation_side='right', special_tokens={'bos_token': '<s>', 'eos_token': '</s>', 'unk_token': '<unk>', 'pad_token': '</s>'}, clean_up_tokenization_spaces=False),  added_tokens_decoder={        0: AddedToken("<unk>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),  1: AddedToken("<s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),    2: AddedToken("</s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),   32000: AddedToken("[INST]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),    32001: AddedToken(" [/INST]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),  32002: AddedToken("[SQL]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),     32003: AddedToken(" [/SQL]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False), })
Beginning merge fc-01JT8GGW43913E0N2GEY1R6GDZ.
Merge from /runs/axo-2025-05-02-12-37-37-8a2a/lora-out
The following values were not passed to `accelerate launch` and had defaults used instead:
        `--num_processes` was set to a value of `1`
        `--num_machines` was set to a value of `1`
        `--mixed_precision` was set to a value of `'no'`
        `--dynamo_backend` was set to a value of `'no'`
To avoid this warning pass in values for each of the problematic parameters or run `accelerate config`.
WARNING: BNB_CUDA_VERSION=121 environment variable detected; loading libbitsandbytes_cuda121.so.
This can be used to load a bitsandbytes version that is different from the PyTorch CUDA version.
If this was unintended set the BNB_CUDA_VERSION variable to an empty string: export BNB_CUDA_VERSION=
If you use the manual override make sure the right libcudart.so is in your LD_LIBRARY_PATH
For example by adding the following to your .bashrc: export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path_to_cuda_dir/lib64

[2025-05-02 12:46:23,634] [INFO] [datasets.<module>:58] [PID:6] PyTorch version 2.3.0+cu121 available.
[2025-05-02 12:46:25,007] [INFO] [real_accelerator.py:203:get_accelerator] Setting ds_accelerator to cuda (auto detect)
df: /root/.triton/autotune: No such file or directory
[2025-05-02 12:46:25,116] [INFO] [root.spawn:38] [PID:6] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -fPIC -O2 -isystem /root/miniconda3/envs/py3.11/include -g0 -fPIC -g0 -c /tmp/tmpphxjihfg/test.c -o /tmp/tmpphxjihfg/test.o
[2025-05-02 12:46:25,158] [INFO] [root.spawn:38] [PID:6] gcc -pthread -B /root/miniconda3/envs/py3.11/compiler_compat /tmp/tmpphxjihfg/test.o -laio -o /tmp/tmpphxjihfg/a.out
 [WARNING]  Please specify the CUTLASS repo directory as environment variable $CUTLASS_PATH
 [WARNING]  sparse_attn requires a torch version >= 1.5 and < 2.0 but detected 2.3
 [WARNING]  using untested triton version (2.3.0), only 1.0.0 is known to be compatible
                                 dP            dP   dP
                                 88            88   88
      .d8888b. dP.  .dP .d8888b. 88 .d8888b. d8888P 88
      88'  `88  `8bd8'  88'  `88 88 88'  `88   88   88
      88.  .88  .d88b.  88.  .88 88 88.  .88   88   88
      `88888P8 dP'  `dP `88888P' dP `88888P'   dP   dP



****************************************
**** Axolotl Dependency Versions *****
  accelerate: 0.30.1
        peft: 0.11.1
transformers: 4.42.3
         trl: 0.8.7.dev0
       torch: 2.3.0+cu121
bitsandbytes: 0.43.1
****************************************
[2025-05-02 12:46:27,268] [WARNING] [axolotl.utils.config.models.input.hint_lora_8bit:1004] [PID:6] [RANK:0] We recommend setting `load_in_8bit: true` for LORA finetuning
[2025-05-02 12:46:27,268] [DEBUG] [axolotl.normalize_config:80] [PID:6] [RANK:0] bf16 support detected, enabling for this configuration.
[2025-05-02 12:46:27,349] [INFO] [axolotl.normalize_config:183] [PID:6] [RANK:0] GPU memory usage baseline: 0.000GB (+0.422GB misc)
[2025-05-02 12:46:27,349] [INFO] [axolotl.common.cli.load_model_and_tokenizer:51] [PID:6] [RANK:0] loading tokenizer... mistralai/Mistral-7B-v0.1
[2025-05-02 12:46:27,573] [DEBUG] [axolotl.load_tokenizer:280] [PID:6] [RANK:0] EOS: 2 / </s>
[2025-05-02 12:46:27,573] [DEBUG] [axolotl.load_tokenizer:281] [PID:6] [RANK:0] BOS: 1 / <s>
[2025-05-02 12:46:27,573] [DEBUG] [axolotl.load_tokenizer:282] [PID:6] [RANK:0] PAD: 2 / </s>
[2025-05-02 12:46:27,573] [DEBUG] [axolotl.load_tokenizer:283] [PID:6] [RANK:0] UNK: 0 / <unk>
[2025-05-02 12:46:27,573] [INFO] [axolotl.load_tokenizer:294] [PID:6] [RANK:0] No Chat template selected. Consider adding a chat template for easier inference.
[2025-05-02 12:46:27,573] [INFO] [axolotl.common.cli.load_model_and_tokenizer:53] [PID:6] [RANK:0] loading model and (optionally) peft_config...
[2025-05-02 12:46:49,221] [INFO] [axolotl.load_model:794] [PID:6] [RANK:0] converting modules to torch.bfloat16 for flash attention
[2025-05-02 12:46:49,458] [INFO] [axolotl.load_lora:951] [PID:6] [RANK:0] found linear modules: ['gate_proj', 'v_proj', 'o_proj', 'k_proj', 'up_proj', 'down_proj', 'q_proj']
[2025-05-02 12:46:49,458] [DEBUG] [axolotl.load_lora:993] [PID:6] [RANK:0] Loading pretrained PEFT - LoRA
trainable params: 304,119,808 || all params: 7,545,884,672 || trainable%: 4.0303
[2025-05-02 12:46:52,249] [INFO] [axolotl.load_model:843] [PID:6] [RANK:0] GPU memory usage after adapters: 0.000GB ()
[2025-05-02 12:46:52,249] [INFO] [axolotl.scripts.do_merge_lora:144] [PID:6] [RANK:0] running merge of LoRA with base model
Unloading and merging model:  98%|█████████▊| 671/684 [00:30<00:00, 19.83it/s]
Unloading and merging model:  99%|█████████▊| 675/684 [00:31<00:00, 14.08it/s]Unloading and merging model: 100%|██████████| 684/684 [00:31<00:00, 21.67it/s]
Run complete. Tag: axo-2025-05-02-12-37-37-8a2a
To inspect outputs, run `modal volume ls example-runs-vol axo-2025-05-02-12-37-37-8a2a`
To run sample inference, run `modal run -q src.inference --run-name axo-2025-05-02-12-37-37-8a2a`
Runner terminated.
✓ App completed. View run at https://modal.com/apps/davidxia/main/ap-3OUD1LsVH6HRjvF87rusVH
```
</details>